### PR TITLE
Refactor: remove author UI from blog and constrain reading width

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Next.js Dev (Turbopack)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    },
+    {
+      "name": "Cloudflare Workers Preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "preview"],
+      "port": 8787
+    }
+  ]
+}

--- a/app/[lang]/(main)/blog/[slug]/page.tsx
+++ b/app/[lang]/(main)/blog/[slug]/page.tsx
@@ -5,7 +5,7 @@ import defaultMdxComponents from "fumadocs-ui/mdx";
 import { blog } from "@/lib/source";
 import { File, Files, Folder } from "fumadocs-ui/components/files";
 import { Tab, Tabs } from "fumadocs-ui/components/tabs";
-import { Language, uiDictionary, localizeUrl, i18n } from "@/lib/i18n";
+import { Language, localizeUrl, i18n } from "@/lib/i18n";
 import { displayDate } from "@/lib/date";
 import { createBlogMetadata, baseUrl } from "@/lib/metadata";
 import { ArticleJsonLd } from "@/components/JsonLd";
@@ -32,7 +32,6 @@ export default async function Page(props: {
 }) {
   const params = await props.params;
   const page = blog.getPage([params.slug], params.lang);
-  const t = uiDictionary[params.lang].blog;
 
   if (!page) notFound();
 
@@ -46,7 +45,7 @@ export default async function Page(props: {
 
   return (
     <div className="relative isolate px-6 py-24 sm:py-32 lg:px-8">
-      <div className="mx-auto max-w-7xl">
+      <div className="mx-auto max-w-3xl">
         <Breadcrumb lang={params.lang} />
         <BreadcrumbJsonLd lang={params.lang} />
         {/* Structured data for the article */}
@@ -59,14 +58,20 @@ export default async function Page(props: {
           url={canonical}
           imageUrl={data.image}
         />
-        <div className="container px-0">
-          <h2 className="text-4xl font-semibold tracking-tight text-pretty opacity-90 sm:text-5xl">
+        <div>
+          <time
+            dateTime={new Date(data.date).toISOString()}
+            className="text-sm opacity-60"
+          >
+            {displayDate(new Date(data.date), params.lang)}
+          </time>
+          <h2 className="mt-2 text-4xl font-semibold tracking-tight text-pretty opacity-90 sm:text-5xl">
             {data.title}
           </h2>
           <p className="mt-2 text-lg/8 opacity-60">{data.description}</p>
         </div>
-        <article className="container flex flex-col px-0 py-8 lg:flex-row">
-          <div className="prose min-w-0 flex-1 lg:pr-8">
+        <article className="py-8">
+          <div className="prose">
             <InlineTOC className="mb-8" items={toc} />
             <Mdx
               components={{
@@ -79,18 +84,6 @@ export default async function Page(props: {
                 Tab,
               }}
             />
-          </div>
-          <div className="flex flex-col gap-4 border-l p-4 text-sm lg:w-[250px]">
-            <div>
-              <p className="mb-1 text-fd-muted-foreground">{t.writtenBy}</p>
-              <p className="font-medium">{data.author}</p>
-            </div>
-            <div>
-              <p className="mb-1 text-sm text-fd-muted-foreground">{t.at}</p>
-              <p className="font-medium">
-                {displayDate(new Date(data.date), params.lang)}
-              </p>
-            </div>
           </div>
         </article>
       </div>
@@ -133,7 +126,7 @@ export async function generateMetadata(props: {
     description: data.description ?? data.title,
     publishedTime,
     modifiedTime,
-    authors: [data.author],
+    authors: data.author ? [data.author] : [],
     tags,
     image: ogImageUrl,
     url: canonical,

--- a/app/[lang]/(main)/blog/[slug]/page.tsx
+++ b/app/[lang]/(main)/blog/[slug]/page.tsx
@@ -54,7 +54,7 @@ export default async function Page(props: {
           description={data.description ?? data.title}
           datePublished={new Date(data.date).toISOString()}
           dateModified={new Date(data.lastModified ?? data.date).toISOString()}
-          authorName={data.author}
+          authorName={data.author ?? ""}
           url={canonical}
           imageUrl={data.image}
         />

--- a/app/[lang]/(main)/blog/atom.xml/route.ts
+++ b/app/[lang]/(main)/blog/atom.xml/route.ts
@@ -38,7 +38,7 @@ export async function GET(
     <id>${link}</id>
     <updated>${updated}</updated>
     <summary>${escape(data.description ?? data.title)}</summary>
-    <author><name>${escape(data.author)}</name></author>
+    ${data.author ? `<author><name>${escape(data.author)}</name></author>` : ""}
   </entry>`;
     })
     .join("");

--- a/app/[lang]/(main)/blog/page.tsx
+++ b/app/[lang]/(main)/blog/page.tsx
@@ -60,22 +60,6 @@ export default async function Page({
                   {post.data.description}
                 </p>
               </div>
-              <div className="relative mt-8 flex items-center gap-x-4">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                  alt={`${post.data.author} avatar`}
-                  src={post.data.authorAvatarLink}
-                  className="size-10 rounded-full bg-neutral-50"
-                />
-                <div className="text-sm/6">
-                  <p className="font-semibold opacity-90">
-                    <a href={post.data.authorLink}>
-                      <span className="absolute inset-0" />
-                      {post.data.author}
-                    </a>
-                  </p>
-                </div>
-              </div>
             </article>
           ))}
         </div>

--- a/app/[lang]/(main)/blog/rss.xml/route.ts
+++ b/app/[lang]/(main)/blog/rss.xml/route.ts
@@ -38,7 +38,7 @@ export async function GET(
       <guid isPermaLink="true">${link}</guid>
       <pubDate>${pub}</pubDate>
       <description>${escape(data.description ?? data.title)}</description>
-      <author>${escape(data.author)}</author>
+      ${data.author ? `<author>${escape(data.author)}</author>` : ""}
     </item>`;
     })
     .join("");

--- a/source.config.ts
+++ b/source.config.ts
@@ -21,9 +21,9 @@ export const blog = defineCollections({
   type: "doc",
   dir: "content/blog",
   schema: frontmatterSchema.extend({
-    author: z.string(),
-    authorAvatarLink: z.string().url().or(z.string()),
-    authorLink: z.string().url(),
+    author: z.string().optional(),
+    authorAvatarLink: z.string().url().or(z.string()).optional(),
+    authorLink: z.string().url().optional(),
     date: z.date(),
     // Optional SEO fields
     image: z.string().url().optional(),


### PR DESCRIPTION
## Changes

- **Removed author sidebar** from individual blog post pages
- **Simplified blog post layout** by constraining max-width from `max-w-7xl` to `max-w-3xl` for better readability
- **Moved publication date** to header above title in blog post pages
- **Made author fields optional** in blog schema (`author`, `authorAvatarLink`, `authorLink`)
- **Updated feed generators** (RSS and Atom) to handle optional author fields gracefully
- **Removed author card UI** from blog listing page
- **Added Claude launch configuration** for development convenience

## Impact

Simplifies the blog interface by focusing on content readability while maintaining backward compatibility with optional author metadata in frontmatter.