### PR TITLE
Add Grafana OnCall sunset blog post in 6 languages

### DIFF
--- a/content/blog/grafana-oncall-sunset.de.mdx
+++ b/content/blog/grafana-oncall-sunset.de.mdx
@@ -1,0 +1,99 @@
+---
+title: "Grafana OnCall wird eingestellt: So bleiben Telefonbenachrichtigungen erhalten"
+description: "Die Cloud Connection von Grafana OnCall OSS wurde am 24. März 2026 deaktiviert. Was das für dein On-Call-Setup bedeutet und wie du Telefonbenachrichtigungen mit Echobell wiederherstellen kannst."
+date: 2026-03-28
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - Grafana OnCall
+  - On-Call-Management
+  - Alert-Benachrichtigungen
+  - Telefonbenachrichtigungen
+  - Migration
+---
+
+# Grafana OnCall wird eingestellt: So bleiben Telefonbenachrichtigungen erhalten
+
+Am 24. März 2026 hat Grafana Labs die Cloud Connection deaktiviert, die SMS-, Telefon- und mobile Push-Benachrichtigungen für selbst gehostete Grafana OnCall-Deployments bereitgestellt hat. Wer Grafana OnCall OSS betreibt, hat seit vier Tagen keine funktionierenden Telefonbenachrichtigungen mehr.
+
+Das kam nicht überraschend. Grafana kündigte den Wartungsmodus bereits im März 2025 an und gab Teams ein Jahr Zeit für die Planung. Die Optionen — Migration zu Grafana Cloud IRM oder eine andere Lösung finden — erfordern jedoch echten Aufwand, und die Frist ist nun abgelaufen.
+
+Was passiert ist, was nicht mehr funktioniert und was du heute tun kannst.
+
+## Was die Abschaltung von Grafana OnCall konkret bedeutet
+
+Grafana OnCall OSS befindet sich seit dem 11. März 2025 im Wartungsmodus. Das Repository ist weiterhin unter AGPLv3 Open Source und kann geforkt werden, aber Grafana Labs hat die Entwicklung neuer Funktionen eingestellt und Fixes auf kritische CVEs beschränkt.
+
+Der wichtigere Stichtag war der 24. März 2026: Der Cloud-Connection-Dienst wurde dauerhaft deaktiviert. Dieser Dienst verwaltete alle ausgehenden Benachrichtigungen, die Grafana-Infrastruktur benötigten:
+
+- SMS-Benachrichtigungen
+- Telefonische Eskalationen
+- Mobile Push-Benachrichtigungen über die Grafana OnCall App
+
+Wer diese Kanäle genutzt hat, um Teams bei Vorfällen zu alarmieren, hat jetzt eine Lücke im System.
+
+Webhook-basierte Benachrichtigungen an Slack, PagerDuty oder eigene Endpunkte funktionieren weiterhin, da sie nie von der Cloud Connection abhingen. Für Teams, die Telefonbenachrichtigungen als letzte Sicherheitsnetz gegen verpasste Alerts eingesetzt haben, ist jedoch eine Lücke entstanden.
+
+## Der offizielle Migrationspfad und seine Kompromisse
+
+Grafanas empfohlener Migrationspfad ist Grafana Cloud IRM. Es konsolidiert die alte OnCall- und Incident-Funktionalität in einem einzigen Cloud-Produkt, mit Migrationswerkzeugen für Teams aus PagerDuty, Opsgenie und Splunk OnCall.
+
+Der Kompromiss liegt bei Kosten und Architektur. Grafana Cloud IRM ist ausschließlich cloud-basiert — es gibt keine selbst gehostete Option. Der Preis liegt bei rund 419 USD/Monat für ein 20-Personen-Team. Für kleine Teams oder Organisationen mit strengen Datenschutzanforderungen verändert das die Kosten-Nutzen-Rechnung erheblich.
+
+Wer den gesamten On-Call-Betrieb zu Grafana Cloud IRM migrieren möchte, findet dort eine vollständige Lösung. Wer jedoch nur eine Sache braucht — Telefonbenachrichtigungen für kritische Grafana-Alerts ohne kompletten Umbau des bestehenden Setups — hat einen leichteren Weg.
+
+## Telefonbenachrichtigungen mit Echobell wiederherstellen
+
+[Echobell](https://apps.apple.com/app/apple-store/id6743748445?ct=blog-grafana-oncall-sunset-de) ist eine mobile App, die Webhook-Aufrufe in Telefonbenachrichtigungen, zeitkritische Benachrichtigungen oder normale Pushes umwandelt. Sie ersetzt nicht den gesamten On-Call-Workflow, aber sie ersetzt genau den Teil, den die Cloud Connection übernommen hatte: das Klingeln des Telefons, wenn etwas Wichtiges ausfällt.
+
+Das Setup funktioniert mit deinen bestehenden Grafana-Alert-Regeln ohne Änderungen.
+
+### Schritt 1 — Kanal in Echobell erstellen
+
+Echobell herunterladen und einen neuen Kanal erstellen. Den Benachrichtigungstyp auf **Anruf** setzen — das ist es, was das Telefon zum Klingeln bringt, anstatt still eine Push-Benachrichtigung zu senden.
+
+### Schritt 2 — Echobell als Grafana Contact Point hinzufügen
+
+In Grafana zu Alerting → Contact points → New contact point navigieren. **Webhook** auswählen und die Webhook-URL des Echobell-Kanals einfügen:
+
+`https://hook.echobell.one/t/YOUR_CHANNEL_ID`
+
+Diese URL ist in den Kanaleinstellungen in der App zu finden.
+
+### Schritt 3 — Kritische Alerts zu Echobell routen
+
+Die Benachrichtigungsrichtlinien aktualisieren, um Alerts mit hohem Schweregrad zum Echobell Contact Point zu routen. Bestehende Slack- oder E-Mail-Kontaktpunkte für niedrigpriorisierte Alerts beibehalten — Echobell ist für die Alerts, bei denen jemand geweckt werden muss.
+
+### Schritt 4 — Testen
+
+Auf **Test** beim Contact Point klicken. Das Telefon sollte innerhalb weniger Sekunden klingeln.
+
+Das ist das Grundsetup. Von diesem Punkt an: Grafana Alert feuert → Echobell empfängt den Webhook → Telefon klingelt.
+
+## Eskalation und Teamabdeckung
+
+Für On-Call-Rotationen können Echobell-Kanäle mit mehreren Teammitgliedern geteilt werden. Alle Abonnenten eines Kanals werden benachrichtigt, wenn ein Alert ausgelöst wird. Das Wiederholungsverhalten lässt sich konfigurieren, sodass der Anruf wiederholt wird, wenn die erste Person nicht antwortet.
+
+Echobell unterstützt drei Dringlichkeitsstufen, die verschiedenen Alert-Schweregraden zugeordnet werden können:
+
+- **Anruf** — klingelt wie ein Telefonanruf, durchbricht den iOS-Fokusmodus und Nicht-Stören
+- **Zeitkritisch** — erscheint sofort auf dem Sperrbildschirm ohne Klingeln
+- **Normal** — Standard-Push-Benachrichtigung
+
+Empfohlene Zuordnung: `critical` → Anruf, `warning` → Zeitkritisch, `info` → Normal.
+
+## Was im Vergleich zu Grafana OnCall fehlt
+
+Echobell ist keine vollständige On-Call-Management-Plattform. Sie bietet keine Schichtpläne, Eskalationsbäume oder Incident-Timelines. Wer das benötigt, braucht eine dedizierte Plattform — PagerDuty, All Quiet oder Grafana Cloud IRM selbst.
+
+Was Echobell abdeckt, ist die Benachrichtigungs-Lieferschicht: sicherstellen, dass die richtigen Personen tatsächlich informiert werden, wenn das Alarmsystem anschlägt. Für Teams, bei denen das der Hauptwert der Cloud Connection von Grafana OnCall war, kann Echobell diese Lücke mit minimalem Aufwand und ohne laufende Infrastrukturkosten schließen.
+
+---
+
+## Verwandte Beiträge
+
+- [Telefonbenachrichtigungen für Grafana-Alerts](/de/blog/grafana-call-notification)
+- [Telefonbenachrichtigungen bei API-Ausfällen](/de/blog/phone-call-alerts-api-downtime)
+- [iOS-Fokusmodus für kritische Alerts umgehen](/de/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [Grafana-Integrationsdokumentation](/de/docs/developer/grafana)

--- a/content/blog/grafana-oncall-sunset.es.mdx
+++ b/content/blog/grafana-oncall-sunset.es.mdx
@@ -1,0 +1,99 @@
+---
+title: "Grafana OnCall se cierra: cómo mantener las alertas telefónicas funcionando"
+description: "La Cloud Connection de Grafana OnCall OSS se desactivó el 24 de marzo de 2026. Esto es lo que significa para tu configuración de guardia y cómo restaurar las alertas telefónicas con Echobell."
+date: 2026-03-28
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - Grafana OnCall
+  - gestión de guardia
+  - notificaciones de alerta
+  - alertas telefónicas
+  - migración
+---
+
+# Grafana OnCall se cierra: cómo mantener las alertas telefónicas funcionando
+
+El 24 de marzo de 2026, Grafana Labs desactivó la Cloud Connection que proporciona SMS, llamadas telefónicas y notificaciones push móviles para los despliegues autohospedados de Grafana OnCall. Si ejecutas Grafana OnCall OSS, tus alertas telefónicas dejaron de funcionar hace cuatro días.
+
+No fue repentino. Grafana anunció la transición al modo de mantenimiento en marzo de 2025, dando a los equipos un año para planificar. Pero las opciones sobre la mesa — migrar a Grafana Cloud IRM o encontrar otra alternativa — ambas requieren trabajo real, y el plazo ya ha pasado.
+
+Esto es lo que ocurrió, qué deja de funcionar y qué puedes hacer hoy.
+
+## Qué significa realmente el cierre de Grafana OnCall
+
+Grafana OnCall OSS ha estado en modo de mantenimiento desde el 11 de marzo de 2025. El repositorio sigue siendo de código abierto bajo AGPLv3 y se puede hacer fork, pero Grafana Labs dejó de añadir funcionalidades y limitó las correcciones a CVEs críticos únicamente.
+
+El punto de corte más importante fue el 24 de marzo de 2026: el servicio de Cloud Connection fue desactivado permanentemente. Este servicio gestionaba todas las notificaciones salientes que requerían la infraestructura de Grafana:
+
+- Alertas por SMS
+- Escaladas por llamada telefónica
+- Notificaciones push móviles a través de la app de Grafana OnCall
+
+Si dependías de alguno de estos canales para despertar a alguien durante los incidentes, esos canales ya no existen.
+
+Las notificaciones basadas en webhook hacia Slack, PagerDuty o endpoints personalizados siguen funcionando ya que nunca dependieron de la Cloud Connection — pero para los equipos que usaban las llamadas telefónicas como última línea de defensa contra alertas perdidas, ahora hay un vacío.
+
+## La ruta oficial y sus compromisos
+
+La ruta de migración recomendada por Grafana es Grafana Cloud IRM. Consolida la antigua funcionalidad de OnCall e Incident en un único producto en la nube, con herramientas de migración para equipos que vienen de PagerDuty, Opsgenie y Splunk OnCall.
+
+El compromiso está en el coste y la arquitectura. Grafana Cloud IRM es solo en la nube — no hay opción autohospedada. El precio ronda los 419 USD/mes para un equipo de 20 personas. Para equipos pequeños u organizaciones con requisitos estrictos de residencia de datos, eso cambia significativamente el cálculo.
+
+Si estás dispuesto a mover toda tu operación de guardia a Grafana Cloud IRM, esa es una solución completa. Pero si tu objetivo es más concreto — específicamente, obtener alertas telefónicas para alertas críticas de Grafana sin reformar toda tu configuración — existe un camino más ligero.
+
+## Restaurar las alertas telefónicas con Echobell
+
+[Echobell](https://apps.apple.com/app/apple-store/id6743748445?ct=blog-grafana-oncall-sunset-es) es una aplicación móvil que convierte llamadas webhook en alertas telefónicas, notificaciones urgentes o pushes estándar. No reemplaza todo el flujo de trabajo de guardia, pero sí reemplaza la pieza específica que manejaba la Cloud Connection: hacer que tu teléfono suene cuando algo importante falla.
+
+La configuración funciona con tus reglas de alerta de Grafana existentes sin cambios.
+
+### Paso 1 — Crear un canal en Echobell
+
+Descarga Echobell y crea un nuevo canal. Establece el tipo de notificación en **Llamada** — esto es lo que hace que tu teléfono suene en lugar de entregar silenciosamente un push.
+
+### Paso 2 — Añadir Echobell como contact point en Grafana
+
+En Grafana, ve a Alerting → Contact points → New contact point. Elige **Webhook** y pega la URL del webhook de tu canal de Echobell:
+
+`https://hook.echobell.one/t/YOUR_CHANNEL_ID`
+
+Puedes encontrar esta URL en la configuración del canal dentro de la app.
+
+### Paso 3 — Enrutar las alertas críticas a Echobell
+
+Actualiza tus políticas de notificación para enrutar las alertas de alta severidad al contact point de Echobell. Mantén los contact points existentes de Slack o email para las alertas de menor prioridad — Echobell es para las alertas que necesitan despertar a alguien.
+
+### Paso 4 — Probarlo
+
+Haz clic en **Test** en el contact point. Tu teléfono debería sonar en pocos segundos.
+
+Esa es la configuración básica. A partir de aquí: se dispara la alerta de Grafana → Echobell recibe el webhook → suena tu teléfono.
+
+## Gestionar la escalada y la cobertura del equipo
+
+Para los turnos de guardia, los canales de Echobell pueden compartirse con varios miembros del equipo. Todos los suscritos a un canal reciben notificaciones cuando se dispara una alerta. Puedes configurar el comportamiento de reintento para que si la primera persona no responde, la llamada se repita.
+
+Echobell también admite tres niveles de urgencia que puedes mapear a diferentes severidades de alerta:
+
+- **Llamada** — suena como una llamada telefónica, atraviesa el Modo Enfoque de iOS y No Molestar
+- **Urgente** — aparece inmediatamente en la pantalla de bloqueo sin sonar
+- **Normal** — notificación push estándar
+
+Mapea tus niveles de severidad de Grafana así: `critical` → llamada, `warning` → urgente, `info` → normal.
+
+## Qué pierdes en comparación con Grafana OnCall
+
+Echobell no es una plataforma completa de gestión de guardia. No tiene horarios de rotación, árboles de escalada ni líneas de tiempo de incidentes. Si necesitas eso, necesitas una plataforma dedicada — PagerDuty, All Quiet o el propio Grafana Cloud IRM.
+
+Lo que Echobell cubre es la capa de entrega de notificaciones: asegurarse de que cuando tu sistema de alertas se activa, las personas adecuadas realmente se enteran. Para los equipos donde ese era el valor principal de la Cloud Connection de Grafana OnCall, Echobell puede llenar ese hueco con una configuración mínima y sin coste de infraestructura por usuario.
+
+---
+
+## Relacionados
+
+- [Notificaciones telefónicas para alertas de Grafana](/es/blog/grafana-call-notification)
+- [Alertas telefónicas cuando tu API cae](/es/blog/phone-call-alerts-api-downtime)
+- [Saltarse el Modo Enfoque de iOS para alertas críticas](/es/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [Documentación de integración con Grafana](/es/docs/developer/grafana)

--- a/content/blog/grafana-oncall-sunset.fr.mdx
+++ b/content/blog/grafana-oncall-sunset.fr.mdx
@@ -1,0 +1,99 @@
+---
+title: "Grafana OnCall ferme : comment conserver les alertes par téléphone"
+description: "La Cloud Connection de Grafana OnCall OSS a été désactivée le 24 mars 2026. Voici ce que cela signifie pour votre configuration d'astreinte et comment restaurer les alertes téléphoniques avec Echobell."
+date: 2026-03-28
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - Grafana OnCall
+  - gestion d'astreinte
+  - notifications d'alerte
+  - alertes téléphoniques
+  - migration
+---
+
+# Grafana OnCall ferme : comment conserver les alertes par téléphone
+
+Le 24 mars 2026, Grafana Labs a désactivé la Cloud Connection qui alimentait les SMS, les appels téléphoniques et les notifications push mobiles pour les déploiements auto-hébergés de Grafana OnCall. Si vous utilisez Grafana OnCall OSS, vos alertes téléphoniques ont cessé de fonctionner il y a quatre jours.
+
+Ce n'était pas soudain. Grafana avait annoncé la transition en mode maintenance dès mars 2025, laissant aux équipes un an pour planifier. Mais les options sur la table — migrer vers Grafana Cloud IRM ou trouver autre chose — nécessitent toutes deux un travail réel, et le délai est maintenant dépassé.
+
+Voici ce qui s'est passé, ce qui ne fonctionne plus et ce que vous pouvez faire aujourd'hui.
+
+## Ce que la fermeture de Grafana OnCall signifie concrètement
+
+Grafana OnCall OSS est en mode maintenance depuis le 11 mars 2025. Le dépôt reste open source sous AGPLv3 et peut être forké, mais Grafana Labs a cessé d'ajouter des fonctionnalités et limité les correctifs aux CVE critiques uniquement.
+
+La coupure la plus importante a eu lieu le 24 mars 2026 : le service Cloud Connection a été définitivement désactivé. Ce service gérait toutes les notifications sortantes nécessitant l'infrastructure Grafana :
+
+- Alertes par SMS
+- Escalades par appel téléphonique
+- Notifications push mobiles via l'application Grafana OnCall
+
+Si vous comptiez sur l'un de ces canaux pour réveiller les équipes lors d'incidents, ces canaux n'existent plus.
+
+Les notifications basées sur webhook vers Slack, PagerDuty ou des endpoints personnalisés continuent de fonctionner car elles n'ont jamais dépendu de la Cloud Connection — mais pour les équipes qui utilisaient les appels téléphoniques comme dernière ligne de défense contre les alertes manquées, il existe désormais un vide.
+
+## La voie officielle et ses compromis
+
+La voie de migration recommandée par Grafana est Grafana Cloud IRM. Elle consolide les anciennes fonctionnalités OnCall et Incident dans un seul produit cloud, avec des outils de migration pour les équipes venant de PagerDuty, Opsgenie et Splunk OnCall.
+
+Le compromis porte sur le coût et l'architecture. Grafana Cloud IRM est uniquement cloud — il n'existe pas d'option auto-hébergée. Le tarif est d'environ 419 USD/mois pour une équipe de 20 personnes. Pour les petites équipes ou les organisations soumises à des exigences strictes de résidence des données, cela change considérablement le calcul.
+
+Si vous êtes prêt à déplacer l'ensemble de votre gestion d'astreinte vers Grafana Cloud IRM, c'est une solution complète. Mais si votre objectif est plus ciblé — obtenir des alertes téléphoniques pour les alertes Grafana critiques sans refondre toute votre configuration — il existe une voie plus légère.
+
+## Restaurer les alertes téléphoniques avec Echobell
+
+[Echobell](https://apps.apple.com/app/apple-store/id6743748445?ct=blog-grafana-oncall-sunset-fr) est une application mobile qui convertit les appels webhook en alertes téléphoniques, en notifications urgentes ou en pushes standard. Elle ne remplace pas l'ensemble du flux de travail d'astreinte, mais elle remplace la pièce spécifique que gérait la Cloud Connection : faire sonner votre téléphone quand quelque chose d'important tombe en panne.
+
+La configuration fonctionne avec vos règles d'alerte Grafana existantes, sans modification.
+
+### Étape 1 — Créer un canal dans Echobell
+
+Téléchargez Echobell et créez un nouveau canal. Définissez le type de notification sur **Appel** — c'est ce qui fait sonner votre téléphone plutôt que de délivrer silencieusement un push.
+
+### Étape 2 — Ajouter Echobell comme contact point dans Grafana
+
+Dans Grafana, allez dans Alerting → Contact points → New contact point. Choisissez **Webhook** et collez l'URL webhook de votre canal Echobell :
+
+`https://hook.echobell.one/t/YOUR_CHANNEL_ID`
+
+Vous trouverez cette URL dans les paramètres du canal dans l'application.
+
+### Étape 3 — Router les alertes critiques vers Echobell
+
+Mettez à jour vos politiques de notification pour router les alertes de haute sévérité vers le contact point Echobell. Conservez vos contacts Slack ou email existants pour les alertes de moindre priorité — Echobell est réservé aux alertes qui nécessitent de réveiller quelqu'un.
+
+### Étape 4 — Tester
+
+Cliquez sur **Test** sur le contact point. Votre téléphone devrait sonner en quelques secondes.
+
+C'est la configuration de base. À partir de là : l'alerte Grafana se déclenche → Echobell reçoit le webhook → votre téléphone sonne.
+
+## Gérer l'escalade et la couverture d'équipe
+
+Pour les rotations d'astreinte, les canaux Echobell peuvent être partagés avec plusieurs membres de l'équipe. Tous les abonnés d'un canal sont notifiés quand une alerte se déclenche. Vous pouvez configurer le comportement de relance pour que si la première personne ne répond pas, l'appel se répète.
+
+Echobell prend également en charge trois niveaux d'urgence que vous pouvez mapper à différentes sévérités d'alerte :
+
+- **Appel** — sonne comme un appel téléphonique, passe à travers le Mode Concentration iOS et Ne pas déranger
+- **Urgent** — apparaît immédiatement sur l'écran de verrouillage sans sonner
+- **Normal** — notification push standard
+
+Mappez ainsi vos niveaux de sévérité Grafana : `critical` → appel, `warning` → urgent, `info` → normal.
+
+## Ce que vous perdez par rapport à Grafana OnCall
+
+Echobell n'est pas une plateforme complète de gestion d'astreinte. Elle n'a pas de plannings de rotation, d'arbres d'escalade ou de chronologies d'incidents. Si vous en avez besoin, vous avez besoin d'une plateforme dédiée — PagerDuty, All Quiet ou Grafana Cloud IRM lui-même.
+
+Ce qu'Echobell couvre, c'est la couche de livraison des notifications : s'assurer que quand votre système d'alerte se déclenche, les bonnes personnes l'apprennent vraiment. Pour les équipes où c'était la valeur principale de la Cloud Connection de Grafana OnCall, Echobell peut combler ce vide avec une configuration minimale et sans coût d'infrastructure par utilisateur.
+
+---
+
+## Articles connexes
+
+- [Notifications téléphoniques pour les alertes Grafana](/fr/blog/grafana-call-notification)
+- [Alertes téléphoniques lors de pannes d'API](/fr/blog/phone-call-alerts-api-downtime)
+- [Contourner le Mode Concentration iOS pour les alertes critiques](/fr/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [Documentation d'intégration Grafana](/fr/docs/developer/grafana)

--- a/content/blog/grafana-oncall-sunset.ja.mdx
+++ b/content/blog/grafana-oncall-sunset.ja.mdx
@@ -1,0 +1,99 @@
+---
+title: "Grafana OnCallのサービス終了：電話アラートを維持する方法"
+description: "Grafana OnCall OSSのCloud Connectionが2026年3月24日に停止しました。オンコール体制への影響と、Echobellで電話アラートを復旧する方法を解説します。"
+date: 2026-03-28
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - Grafana OnCall
+  - オンコール管理
+  - アラート通知
+  - 電話アラート
+  - 移行
+---
+
+# Grafana OnCallのサービス終了：電話アラートを維持する方法
+
+2026年3月24日、Grafana Labsはセルフホスト型Grafana OnCallデプロイメントのSMS・電話・モバイルプッシュ通知を提供するCloud Connectionを永久停止しました。Grafana OnCall OSSを運用している場合、4日前から電話アラートが機能しなくなっています。
+
+これは突然の出来事ではありませんでした。GrafanaはメンテナンスモードへのTransitionを2025年3月に発表し、チームに1年間の準備期間を与えました。しかし、選択肢として提示されたGrafana Cloud IRMへの移行または代替手段の模索は、いずれも相当の作業量を必要とします。そして期限はすでに過ぎています。
+
+何が起きたのか、何が動かなくなったのか、そして今日から何ができるかを説明します。
+
+## Grafana OnCall停止が実際に意味すること
+
+Grafana OnCall OSSは2025年3月11日からメンテナンスモードに入っています。リポジトリはAGPLv3でオープンソースとして継続されており、フォークも可能ですが、Grafana Labsは新機能の追加を停止し、修正をCVSSスコア7.0以上の重大CVEのみに限定しました。
+
+より重要な節目は2026年3月24日で、Cloud Connectionサービスが永久停止されました。このサービスはGrafanaのインフラストラクチャを必要とするすべての送信通知を処理していました：
+
+- SMSアラート
+- 電話エスカレーション
+- Grafana OnCallアプリ経由のモバイルプッシュ通知
+
+インシデント発生時にチームを呼び起こすためにこれらのチャネルに依存していた場合、それらは今や使えなくなっています。
+
+Slack、PagerDutyやカスタムエンドポイントへのWebhookベースの通知は、Cloud Connectionに依存していなかったため引き続き機能しています。しかし、見逃しアラートへの最後の防衛線として電話アラートを使用していたチームには、今や空白が生まれています。
+
+## 公式移行パスとそのトレードオフ
+
+Grafanaが推奨する移行パスはGrafana Cloud IRMです。旧来のOnCallとIncident機能を単一のクラウド製品に統合し、PagerDuty、Opsgenie、Splunk OnCallからの移行ツールも提供されています。
+
+トレードオフはコストとアーキテクチャです。Grafana Cloud IRMはクラウド専用で、セルフホストオプションは存在しません。20名チームの場合、月額約419ドルが必要です。小規模チームや厳格なデータレジデンシー要件がある組織にとっては、コスト計算が大きく変わります。
+
+オンコール運用全体をGrafana Cloud IRMに移行するつもりであれば、それは完全なソリューションです。しかし、目標がより限定的な場合——つまり、既存の設定を大幅に変更せずにGrafanaの重要アラートに対する電話通知を復旧させたいだけであれば——より軽量なパスが存在します。
+
+## Echobellで電話アラートを復旧する
+
+[Echobell](https://apps.apple.com/app/apple-store/id6743748445?ct=blog-grafana-oncall-sunset-ja)は、Webhookコールを電話アラート、時間的に重要な通知、または標準プッシュに変換するモバイルアプリです。オンコール管理ワークフロー全体を置き換えるものではありませんが、Cloud Connectionが担っていた具体的な役割——重要な障害発生時に電話を鳴らすこと——を置き換えます。
+
+既存のGrafanaアラートルールを変更する必要はありません。
+
+### ステップ1 — Echobellでチャンネルを作成
+
+Echobellをダウンロードして新しいチャンネルを作成します。通知タイプを**着信音**に設定します——これにより、サイレントプッシュではなく実際に電話が鳴ります。
+
+### ステップ2 — GrafanaにEchobellをContact Pointとして追加
+
+Grafanaで、Alerting → Contact points → New contact pointに移動します。**Webhook**を選択し、EchobellチャンネルのWebhook URLを貼り付けます：
+
+`https://hook.echobell.one/t/YOUR_CHANNEL_ID`
+
+このURLはアプリ内のチャンネル設定で確認できます。
+
+### ステップ3 — 重要アラートをEchobellにルーティング
+
+高重要度のアラートをEchobell Contact Pointにルーティングするよう通知ポリシーを更新します。優先度の低いアラートには既存のSlackやメールのContact Pointを維持します——Echobellは誰かを呼び起こす必要があるアラートのためのものです。
+
+### ステップ4 — テスト
+
+Contact Pointの**テスト**をクリックします。数秒以内に電話が鳴るはずです。
+
+これが基本設定です。この時点から：Grafanaアラートが発火 → EchobellがWebhookを受信 → 電話が鳴る。
+
+## エスカレーションとチームカバレッジの管理
+
+オンコールローテーションには、Echobellのチャンネルを複数のチームメンバーと共有できます。チャンネルを購読しているすべての人がアラート発火時に通知を受け取ります。最初の人が応答しなかった場合に呼び出しを繰り返すリトライ動作を設定できます。
+
+Echobellは異なるアラート重要度にマッピングできる3段階の緊急度もサポートしています：
+
+- **着信音** — 電話のように鳴り、iOSの集中モードおよびおやすみモードを突破する
+- **時間的に重要** — 鳴動なしでロック画面に即座に表示される
+- **通常** — 標準プッシュ通知
+
+Grafanaのアラート重要度をこのようにマッピングします：`critical` → 着信音、`warning` → 時間的に重要、`info` → 通常。
+
+## Grafana OnCallと比較して失うもの
+
+Echobellは完全なオンコール管理プラットフォームではありません。ローテーションスケジュール、エスカレーションツリー、インシデントタイムラインはありません。それらが必要な場合は、専用プラットフォーム——PagerDuty、All Quiet、またはGrafana Cloud IRM自体——が必要です。
+
+Echobellがカバーするのは通知デリバリー層です：アラートシステムが発火したとき、適切な人々が実際に通知を受け取れるようにすること。Grafana OnCallのCloud Connectionの主な価値がそこにあったチームにとって、Echobellは最小限のセットアップとユーザーあたりのインフラコストなしにそのギャップを埋めることができます。
+
+---
+
+## 関連記事
+
+- [GrafanaアラートへのEchobellによる電話通知](/ja/blog/grafana-call-notification)
+- [APIダウン時に電話アラートを受け取る](/ja/blog/phone-call-alerts-api-downtime)
+- [重要アラートのためiOS集中モードを回避する](/ja/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [Grafana統合ドキュメント](/ja/docs/developer/grafana)

--- a/content/blog/grafana-oncall-sunset.mdx
+++ b/content/blog/grafana-oncall-sunset.mdx
@@ -1,0 +1,99 @@
+---
+title: "Grafana OnCall Is Shutting Down: How to Keep Phone Call Alerts Working"
+description: "Grafana OnCall OSS Cloud Connection shut down on March 24, 2026. Here is what that means for your on-call setup and how to restore phone call alerts with Echobell."
+date: 2026-03-28
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - Grafana OnCall
+  - on-call management
+  - alert notifications
+  - phone call alerts
+  - migration
+---
+
+# Grafana OnCall Is Shutting Down: How to Keep Phone Call Alerts Working
+
+On March 24, 2026, Grafana Labs deactivated the Cloud Connection that powers SMS, phone calls, and mobile push notifications for self-hosted Grafana OnCall deployments. If you are running Grafana OnCall OSS, your phone call alerts stopped working four days ago.
+
+This was not sudden. Grafana announced the maintenance mode transition back in March 2025, giving teams a year to plan. But the options on the table — migrate to Grafana Cloud IRM or find something else — both require real work, and the deadline has now passed.
+
+Here is what happened, what breaks, and what you can do today.
+
+## What Grafana OnCall's shutdown actually means
+
+Grafana OnCall OSS has been in maintenance mode since March 11, 2025. The repository is still open source under AGPLv3 and you can still fork it, but Grafana Labs stopped adding features and limited fixes to critical CVEs only.
+
+The more important cutoff was March 24, 2026: the Cloud Connection service was permanently deactivated. This service handled all outbound notifications that required Grafana infrastructure:
+
+- SMS alerts
+- Phone call escalations
+- Mobile push notifications via the Grafana OnCall app
+
+If you relied on any of these to wake people up during incidents, those channels are now gone.
+
+Webhook-based notifications to Slack, PagerDuty, or custom endpoints still work since they never depended on the Cloud Connection — but for teams that used on-call phone calls as their last line of defense against a missed alert, there is now a gap.
+
+## The official path and its tradeoffs
+
+Grafana's recommended migration path is Grafana Cloud IRM. It consolidates the old OnCall and Incident functionality into a single cloud product, and migration tooling exists for teams coming from PagerDuty, Opsgenie, and Splunk OnCall.
+
+The tradeoff is cost and architecture. Grafana Cloud IRM is cloud-only — there is no self-hosted option. Pricing runs roughly $419/month for a 20-person team. For small teams or organizations with strict data residency requirements, that changes the calculus significantly.
+
+If you are happy to move your entire on-call operation to Grafana Cloud IRM, that is a complete solution. But if your goal is narrower — specifically, getting phone call alerts for critical Grafana alerts without overhauling your setup — there is a lighter path.
+
+## Restoring phone call alerts with Echobell
+
+[Echobell](https://apps.apple.com/app/apple-store/id6743748445?ct=blog-grafana-oncall-sunset-en) is a mobile app that turns webhook calls into phone call alerts, time-sensitive notifications, or standard pushes. It does not replace your entire on-call management workflow, but it does replace the specific piece that the Cloud Connection handled: making your phone ring when something important breaks.
+
+The setup works with your existing Grafana alert rules unchanged.
+
+### Step 1 — Create a channel in Echobell
+
+Download Echobell and create a new channel. Set the notification type to **Calling** — this is what makes your phone ring rather than silently delivering a push.
+
+### Step 2 — Add Echobell as a Grafana contact point
+
+In Grafana, go to Alerting → Contact points → New contact point. Choose **Webhook** and paste your Echobell channel's webhook URL:
+
+`https://hook.echobell.one/t/YOUR_CHANNEL_ID`
+
+You can find this URL in your channel settings inside the app.
+
+### Step 3 — Route critical alerts to Echobell
+
+Update your notification policies to route high-severity alerts to the Echobell contact point. Keep your existing Slack or email contact points for lower-priority alerts — Echobell is for the alerts that need to wake someone up.
+
+### Step 4 — Test it
+
+Click **Test** on the contact point. Your phone should ring within a few seconds.
+
+That is the core setup. From this point, your Grafana alerts fire → Echobell receives the webhook → your phone rings.
+
+## Handling escalation and team coverage
+
+For on-call rotations, Echobell channels can be shared with multiple team members. Everyone subscribed to a channel gets notified when an alert fires. You can configure retry behavior so that if the first person does not respond, the call repeats.
+
+Echobell also supports three urgency tiers you can map to different alert severities:
+
+- **Calling** — rings like a phone call, breaks through iOS Focus Mode and Do Not Disturb
+- **Time-sensitive** — appears immediately on the lock screen without ringing
+- **Normal** — standard push notification
+
+Map these to your Grafana alert severity levels: `critical` to calling, `warning` to time-sensitive, `info` to normal.
+
+## What you lose versus Grafana OnCall
+
+Echobell is not a full on-call management platform. It does not have rotation schedules, escalation trees, or incident timelines. If you need those, you need a dedicated platform — PagerDuty, All Quiet, or Grafana Cloud IRM itself.
+
+What Echobell covers is the notification delivery layer: making sure that when your alerting system fires, the right people actually hear about it. For teams where that was the primary value of Grafana OnCall's Cloud Connection, Echobell can fill that gap with minimal setup and no per-seat infrastructure cost.
+
+---
+
+## Related
+
+- [Phone call notifications for Grafana alerts](/en/blog/grafana-call-notification)
+- [Getting phone call alerts when your API goes down](/en/blog/phone-call-alerts-api-downtime)
+- [Bypassing iOS Focus Mode for critical alerts](/en/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [Grafana integration docs](/en/docs/developer/grafana)

--- a/content/blog/grafana-oncall-sunset.zh.mdx
+++ b/content/blog/grafana-oncall-sunset.zh.mdx
@@ -1,0 +1,99 @@
+---
+title: "Grafana OnCall 即将关闭：如何继续接收电话告警"
+description: "Grafana OnCall OSS 云连接于 2026 年 3 月 24 日停止服务。本文介绍这对你的值班体系意味着什么，以及如何用 Echobell 恢复电话告警功能。"
+date: 2026-03-28
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - Grafana OnCall
+  - 值班管理
+  - 告警通知
+  - 电话告警
+  - 迁移
+---
+
+# Grafana OnCall 即将关闭：如何继续接收电话告警
+
+2026 年 3 月 24 日，Grafana Labs 永久停用了为自托管 Grafana OnCall 部署提供短信、电话和移动推送通知的云连接（Cloud Connection）服务。如果你正在运行 Grafana OnCall OSS，你的电话告警在四天前就已停止工作。
+
+这并非突如其来。Grafana 早在 2025 年 3 月就宣布进入维护模式，给了各团队一年的时间来规划迁移。但摆在面前的两个选择——迁移到 Grafana Cloud IRM 或寻找其他方案——都需要实质性的工作量，而截止日期已经过去。
+
+以下是事情的来龙去脉、受影响的功能，以及你今天可以采取的行动。
+
+## Grafana OnCall 关闭究竟意味着什么
+
+Grafana OnCall OSS 自 2025 年 3 月 11 日起进入维护模式。该代码仓库仍以 AGPLv3 开源协议运行，你可以 fork 它继续使用，但 Grafana Labs 已停止新功能开发，修复工作仅限于 CVSS 评分 7.0 以上的严重安全漏洞。
+
+更关键的截止点是 2026 年 3 月 24 日：云连接服务被永久停用。该服务负责处理所有依赖 Grafana 基础设施的出站通知：
+
+- 短信告警
+- 电话升级通知
+- 通过 Grafana OnCall 应用发送的移动推送通知
+
+如果你依赖这些方式在事故发生时叫醒值班人员，这些渠道现在已经全部失效。
+
+基于 Webhook 的通知（发往 Slack、PagerDuty 或自定义端点）仍然正常工作，因为它们从未依赖云连接——但对于那些将电话告警作为最后一道防线的团队来说，现在出现了一个缺口。
+
+## 官方迁移路径及其取舍
+
+Grafana 推荐的迁移路径是 Grafana Cloud IRM，它将原有的 OnCall 和 Incident 功能整合为一个云端产品，并为从 PagerDuty、Opsgenie 和 Splunk OnCall 迁移过来的团队提供了迁移工具。
+
+但代价是成本和架构层面的改变。Grafana Cloud IRM 仅提供云端版本，没有自托管选项。一个 20 人团队的费用约为每月 419 美元。对于小团队或有严格数据驻留要求的组织而言，这会显著改变决策权衡。
+
+如果你愿意将整个值班运营迁移到 Grafana Cloud IRM，那是一个完整的解决方案。但如果你的目标更为具体——仅仅是在不大幅改变现有体系的情况下，为关键 Grafana 告警恢复电话通知功能——那么有一条更轻量的路径。
+
+## 用 Echobell 恢复电话告警
+
+[Echobell](https://apps.apple.com/app/apple-store/id6743748445?ct=blog-grafana-oncall-sunset-zh) 是一款移动应用，可将 Webhook 调用转换为电话告警、紧急通知或普通推送。它不会取代你完整的值班管理工作流，但它确实替代了云连接所承担的那个具体功能：在重要故障发生时让你的手机真正响起来。
+
+整个设置过程完全兼容你现有的 Grafana 告警规则，无需修改。
+
+### 第一步 — 在 Echobell 中创建频道
+
+下载 Echobell 并创建一个新频道。将通知类型设置为**来电铃声**——这才是让手机真正响铃的设置，而不仅仅是静默推送。
+
+### 第二步 — 在 Grafana 中添加 Echobell 联系点
+
+在 Grafana 中，进入 Alerting → Contact points → New contact point，选择 **Webhook**，然后粘贴你的 Echobell 频道 Webhook 地址：
+
+`https://hook.echobell.one/t/YOUR_CHANNEL_ID`
+
+你可以在应用内的频道设置中找到这个地址。
+
+### 第三步 — 将关键告警路由到 Echobell
+
+更新你的通知策略，将高严重级别的告警路由到 Echobell 联系点。对于优先级较低的告警，保留现有的 Slack 或邮件联系点——Echobell 专门用于那些需要叫醒人的告警。
+
+### 第四步 — 测试
+
+点击联系点上的**测试**按钮，你的手机应在几秒内响起。
+
+核心配置就这些。从此以后：Grafana 告警触发 → Echobell 接收 Webhook → 你的手机响铃。
+
+## 处理升级和团队覆盖
+
+对于值班轮换，Echobell 频道可以与多位团队成员共享。所有订阅该频道的人都会在告警触发时收到通知。你可以配置重试行为，如果第一个人没有响应，通知会自动重复。
+
+Echobell 还支持三个紧急级别，可以映射到不同的告警严重程度：
+
+- **来电铃声** — 像电话一样响铃，能穿透 iOS 专注模式和勿扰模式
+- **紧急通知** — 立即显示在锁屏上，但不响铃
+- **普通通知** — 标准推送通知
+
+建议这样映射你的 Grafana 告警严重级别：`critical` 对应来电铃声，`warning` 对应紧急通知，`info` 对应普通通知。
+
+## 与 Grafana OnCall 相比你会失去什么
+
+Echobell 不是一个完整的值班管理平台，它没有轮班日程、升级树或事故时间线。如果你需要这些功能，你需要一个专门的平台——PagerDuty、All Quiet 或 Grafana Cloud IRM 本身。
+
+Echobell 覆盖的是通知传递层：确保你的告警系统触发时，相关人员真的能收到通知。对于那些将云连接的主要价值定位于此的团队，Echobell 可以以最少的配置和无需按席位付费的方式填补这个缺口。
+
+---
+
+## 相关内容
+
+- [Grafana 告警的电话通知](/zh/blog/grafana-call-notification)
+- [API 宕机时接收电话告警](/zh/blog/phone-call-alerts-api-downtime)
+- [绕过 iOS 专注模式接收关键告警](/zh/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [Grafana 集成文档](/zh/docs/developer/grafana)


### PR DESCRIPTION
## Summary

Add multilingual blog post covering the Grafana OnCall Cloud Connection shutdown (March 24, 2026) and migration guidance.

## Changes

- **English** (`grafana-oncall-sunset.mdx`) - Main blog post
- **German** (`grafana-oncall-sunset.de.mdx`) - German translation
- **Spanish** (`grafana-oncall-sunset.es.mdx`) - Spanish translation
- **French** (`grafana-oncall-sunset.fr.mdx`) - French translation
- **Japanese** (`grafana-oncall-sunset.ja.mdx`) - Japanese translation
- **Chinese** (`grafana-oncall-sunset.zh.mdx`) - Simplified Chinese translation

## Content Coverage

Each post explains:
- What the Cloud Connection shutdown means (SMS, phone, push notifications disabled)
- Official Grafana Cloud IRM migration path and costs
- Lightweight alternative using Echobell for phone call alerts
- Step-by-step Echobell setup with Grafana
- Team coverage and escalation configuration
- Feature comparison with full on-call platforms

Published: March 28, 2026