### PR TITLE
Add alert fatigue blog post (6 languages)

### DIFF
--- a/content/blog/fix-alert-fatigue-developer-guide.de.mdx
+++ b/content/blog/fix-alert-fatigue-developer-guide.de.mdx
@@ -1,0 +1,169 @@
+---
+title: "Alert-Müdigkeit ist real: So lösen clevere Entwickler das Problem"
+description: "Wenn jede Benachrichtigung gleich dringend wirkt, fühlt sich nichts mehr dringend an. So verbesserst du dein Monitoring mit gestuften Benachrichtigungen — und welche Tools gut mit Echobell zusammenspielen."
+date: 2026-04-17
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - Alert-Müdigkeit
+  - Monitoring
+  - Sentry
+  - Prometheus
+  - CloudWatch
+  - DevOps
+---
+
+# Alert-Müdigkeit ist real: So lösen clevere Entwickler das Problem
+
+Es gibt sogar einen Namen dafür: Alert-Müdigkeit. Das ist das Phänomen, wenn deine Monitoring-Tools so viele Benachrichtigungen senden, dass dein Gehirn sie automatisch ausblendet — auch die, die wirklich wichtig sind.
+
+Es fängt meist klein an. Du richtest E-Mail-Alerts für jeden 5xx-Fehler ein. Dann Slack-Benachrichtigungen für jeden fehlgeschlagenen Build. Dann Datadog-Pings, Sentry-Mails, UptimeRobot-Textnachrichten. Innerhalb eines Monats vibriert dein Handy 50 Mal täglich und nichts davon fühlt sich dringend an. Das wirklich Schlimme? Wenn tatsächlich etwas kaputtgeht, hast du dich schon darauf trainiert, es zu ignorieren.
+
+Alert-Müdigkeit zerstört die Reaktionszeit. Und eine schlechte Reaktionszeit zerstört Produkte.
+
+## Warum die meisten Monitoring-Setups mehr Lärm als Signal erzeugen
+
+Das grundlegende Problem ist, dass die meisten Alert-Tools alle Ereignisse gleich behandeln. Ein instabiler Test, der in 10 % der Fälle fehlschlägt, bekommt das gleiche Benachrichtigungsformat wie „die Zahlungs-API gibt für jeden Nutzer 500er zurück." Eines davon braucht um 2 Uhr nachts einen Anruf. Das andere sollte vielleicht in einem wöchentlichen Bericht auftauchen.
+
+Wenn alles gleich behandelt wird, fangen Menschen an, alles zu ignorieren.
+
+Die Lösung ist nicht weniger Alerts — sondern eine intelligentere Zustellung. Das gleiche Ereignis mit unterschiedlichem Schweregrad oder unterschiedlicher Häufigkeit sollte unterschiedliche Dringlichkeitsstufen auf deinem Handy erzeugen.
+
+## Der Drei-Stufen-Ansatz
+
+Echobell bietet drei Zustellmodi, und alle drei gut zu nutzen ist der Kern der Lösung:
+
+- **Aktiv (Normal):** Standard-Push-Benachrichtigung. Gut für informative Ereignisse, die keine sofortige Reaktion erfordern.
+- **Zeitkritisch:** Durchbricht den iOS-Fokus-Modus. Gut für Dinge, die innerhalb der nächsten Stunde oder zwei bearbeitet werden müssen.
+- **Anruf:** Lässt dein Handy wie ein eingehender Anruf klingeln. Reserviere das für „sofort beheben, sonst gibt es echte Konsequenzen."
+
+Das Ziel ist, die Anruf-Stufe für Ereignisse zu erhalten, bei denen eine verzögerte Reaktion echte Folgen hat — Umsatzverluste, Kaskadenausfälle, gefährdete Nutzerdaten. Alles andere fällt auf zeitkritisch oder niedriger.
+
+## Sentry: Nicht mehr für jede Python-Exception angepiept werden
+
+Sentry ist das Paradebeispiel für Alert-Müdigkeit. Standardmäßig sendet es für jeden neuen Issue-Typ eine E-Mail. Auf einer aktiven Codebase in einer normalen Woche ist das ein Feuerschlauch.
+
+Ein schlaueres Setup:
+
+1. In Sentry: **Alerts → Alert erstellen → Issue Alert**
+2. Bedingung hinzufügen: `Das Issue wurde mehr als 10 Mal in 1 Stunde gesehen`
+3. Aktion hinzufügen: **Benachrichtigung via Webhook** → deine Echobell-Kanal-URL einfügen
+4. Benachrichtigungstyp des Kanals auf `zeitkritisch` setzen
+
+Für wirklich kritische Pfade — unbehandelte Exceptions in Zahlungsabläufen, Auth-Fehler, Datenbeschädigungen — erstelle einen separaten Alert mit niedrigerem Schwellenwert und einem `Anruf`-Kanal in Echobell. Dieser Kanal klingelt nur, wenn genau dieser kritische Pfad bricht.
+
+Das Ergebnis: Routine-Issues sammeln sich still in deinem Sentry-Dashboard. Produktionsprobleme rufen dich an.
+
+## Prometheus und AlertManager: Nach Schweregrad routen
+
+Wenn du Prometheus betreibst, hast du bereits AlertManager für das Routing. Du kannst Alerts direkt an Echobell senden, indem du es als Webhook-Empfänger hinzufügst.
+
+In deiner `alertmanager.yml`:
+
+```yaml
+receivers:
+  - name: echobell-critical
+    webhook_configs:
+      - url: https://hook.echobell.one/YOUR_CHANNEL_ID
+        send_resolved: true
+
+  - name: slack-warnings
+    slack_configs:
+      - api_url: YOUR_SLACK_WEBHOOK
+
+route:
+  group_by: ['alertname', 'job']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: slack-warnings
+  routes:
+    - match:
+        severity: critical
+      receiver: echobell-critical
+```
+
+Mit diesem Setup gehen `severity: critical`-Alerts an Echobell und rufen dich an; Warnungen gehen nach Slack, wo sie bis morgen früh warten können. Du musst keine einzige Prometheus-Regel ändern — nur die Routing-Schicht in AlertManager hinzufügen.
+
+Setze den Echobell-Kanal selbst auf **Anruf**. Wenn AlertManager es als kritisch einstuft, verdient es auch einen echten Klingelton.
+
+## AWS CloudWatch: SNS → Lambda → Echobell
+
+CloudWatch hat keinen nativen Webhook-Output, aber du kommst in wenigen Minuten mit SNS und einer kleinen Lambda-Funktion ans Ziel.
+
+1. Erstelle ein SNS-Topic und verknüpfe es mit deinem CloudWatch-Alarm
+2. Erstelle eine Lambda-Funktion, die dieses Topic abonniert:
+
+```python
+import json
+import urllib.request
+
+def lambda_handler(event, context):
+    message = json.loads(event['Records'][0]['Sns']['Message'])
+    alarm_state = message.get('NewStateValue', 'UNKNOWN')
+
+    payload = {
+        "title": f"AWS: {message['AlarmName']}",
+        "body": message.get('NewStateReason', 'Keine Details'),
+        "notificationType": "calling" if alarm_state == "ALARM" else "active"
+    }
+
+    req = urllib.request.Request(
+        'https://hook.echobell.one/YOUR_CHANNEL_ID',
+        data=json.dumps(payload).encode(),
+        headers={'Content-Type': 'application/json'},
+        method='POST'
+    )
+    urllib.request.urlopen(req)
+```
+
+Dieses Muster funktioniert für jeden AWS-Dienst, der SNS unterstützt: RDS-Ereignisse, ECS-Dienstausfälle, Abrechnungsschwellenwert-Alerts, EC2-Instanzstatusänderungen. Einmal eine Lambda-Funktion einrichten, mit SNS verbinden — und jeder CloudWatch-Alarm wird zum Anruf, wenn er wirklich auslöst.
+
+## Alert-Routing zur Team-Entscheidung machen
+
+Der echte Hebel bei gestuften Alerts ist, die Routing-Entscheidung explizit zu machen — nicht etwas, das irgendwann jemand konfiguriert hat und das niemand mehr findet.
+
+Eine praktische Struktur für ein kleines Engineering-Team:
+
+| Kanal | Typ | Wer abonniert |
+|---|---|---|
+| `production-api-critical` | Anruf | Diensthabender Ingenieur |
+| `production-api-warnings` | Zeitkritisch | Ganzes Dev-Team |
+| `staging-all` | Aktiv | Dev-Team (optional) |
+| `background-jobs` | Aktiv | Interessierte |
+
+Wenn sich der On-Call-Dienst ändert, kündigt die ausgehende Person das Abonnement des kritischen Kanals und die eingehende Person abonniert ihn. Das ist die gesamte Rotationsübergabe — keine Config-Dateien, kein Admin-Panel.
+
+Echobell-Kanäle sind per Link teilbar, das Abonnieren dauert für neue Teammitglieder etwa 10 Sekunden.
+
+## Der Signal-zu-Rauschen-Test
+
+Bevor du einen neuen Alert hinzufügst, stelle dir eine Frage: Wenn das um 3 Uhr nachts am Freitag auslöst — was tue ich eigentlich?
+
+- „Aufwachen und sofort beheben" → Anruf
+- „Gleich morgens früh erledigen" → Zeitkritisch oder Aktiv
+- „Wahrscheinlich nichts, ich würde wieder einschlafen" → überdenke, ob der Alert überhaupt existieren sollte
+
+Die meisten Monitoring-Setups haben zu viele Dinge in der ersten Kategorie und zu wenige in der zweiten. Die richtige Antwort für die Mehrheit der Ereignisse ist „morgen erledigen," und eine zeitkritische Benachrichtigung, die lautlos auf dem Sperrbildschirm erscheint, ist genau das richtige Werkzeug dafür.
+
+## Eine Änderung nach der anderen
+
+Wenn dein aktuelles Setup Alert-Müdigkeit erzeugt, ist die schnellste Lösung kein kompletter Umbau. Wähle deine lauteste Quelle — wahrscheinlich Sentry-Mails oder einen Slack-Kanal, den alle stummgeschaltet haben — und kategorisiere jeden Ereignistyp in Anruf, Zeitkritisch oder Aktiv.
+
+Eine Quelle. Eine Woche. Schau, ob das Rauschen sinkt, ohne Signal zu verlieren.
+
+Dann die nächste Quelle angehen.
+
+Ein gut abgestimmtes Alert-Setup ist eins dieser Dinge, das deinen täglichen Arbeitsalltag still und leise verbessert, ohne Drama. Du hörst auf, dein Handy zu fürchten. Du beginnst darauf zu vertrauen, dass wenn es klingelt, es wirklich etwas bedeutet.
+
+---
+
+## Verwandte
+
+- [Telefonische Warnungen bei API-Ausfällen](/en/blog/phone-call-alerts-api-downtime)
+- [Grafana-Anrufbenachrichtigungen mit Echobell](/en/blog/grafana-call-notification)
+- [iOS-Fokus-Modus für kritische Alerts umgehen](/en/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [Zeitfenster-Bedingungen für intelligentere Alert-Zustellung](/en/blog/time-window-notifications-using-utc-conditions)
+- [Automatisierungs-Hub mit n8n und Echobell aufbauen](/en/blog/n8n-echobell-automation-hub)
+- [Webhook-Benachrichtigungen für iPhone](/en/features/webhooks)

--- a/content/blog/fix-alert-fatigue-developer-guide.es.mdx
+++ b/content/blog/fix-alert-fatigue-developer-guide.es.mdx
@@ -1,0 +1,169 @@
+---
+title: "La fatiga de alertas es real: cómo la resuelven los desarrolladores inteligentes"
+description: "Cuando todas las alertas parecen igual de urgentes, ninguna lo parece. Así es como mejorar tu configuración de monitoreo con notificaciones por niveles — y qué herramientas funcionan bien con Echobell."
+date: 2026-04-17
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - fatiga de alertas
+  - monitoreo
+  - Sentry
+  - Prometheus
+  - CloudWatch
+  - DevOps
+---
+
+# La fatiga de alertas es real: cómo la resuelven los desarrolladores inteligentes
+
+Tiene nombre propio: fatiga de alertas. Es lo que ocurre cuando tus herramientas de monitoreo envían tantas notificaciones que tu cerebro empieza a filtrarlas automáticamente — incluso las que realmente importan.
+
+Suele comenzar poco a poco. Configuras alertas por email para cada error 5xx. Luego notificaciones de Slack para cada build fallido. Después pings de Datadog, emails de Sentry, mensajes de UptimeRobot. En un mes, tu teléfono vibra 50 veces al día y nada parece urgente. Lo peor: cuando algo realmente se rompe, ya te has entrenado para ignorarlo.
+
+La fatiga de alertas destruye el tiempo de respuesta. Y un tiempo de respuesta lento destruye los productos.
+
+## Por qué la mayoría de los setups de monitoreo generan más ruido que señal
+
+El problema fundamental es que la mayoría de las herramientas de alertas tratan todos los eventos igual. Una prueba inestable que falla el 10 % del tiempo recibe el mismo formato de notificación que "la API de pagos está devolviendo 500 para todos los usuarios." Uno de esos necesita una llamada a las 2 de la madrugada. El otro debería aparecer en un resumen semanal.
+
+Cuando todo recibe el mismo trato, las personas terminan ignorando todo.
+
+La solución no es menos alertas — es una entrega más inteligente. El mismo evento con diferente nivel de severidad o frecuencia debería producir diferentes niveles de urgencia en tu teléfono.
+
+## El enfoque de tres niveles
+
+Echobell ofrece tres modos de entrega, y usar bien los tres es la clave:
+
+- **Activo (Normal):** Notificación push estándar. Ideal para eventos informativos que no requieren acción inmediata.
+- **Con urgencia temporal:** Atraviesa el Modo Enfoque de iOS. Ideal para cosas que necesitan atención en la próxima hora o dos.
+- **Llamada:** Hace sonar tu teléfono como una llamada entrante. Reserva esto para "arréglalo ahora mismo o habrá consecuencias reales."
+
+El objetivo es preservar el nivel de llamada para eventos donde una respuesta tardía tiene consecuencias reales — ingresos perdidos, fallos en cascada, datos de usuarios en riesgo. Todo lo demás cae a urgencia temporal o menos.
+
+## Sentry: deja de recibir alertas por cada excepción de Python
+
+Sentry es el ejemplo canónico de fatiga de alertas. Por defecto, envía un email por cada nuevo tipo de issue. En una base de código activa durante una semana normal, eso es un flujo imparable.
+
+Un setup más inteligente:
+
+1. En Sentry: **Alertas → Crear alerta → Alerta de issue**
+2. Agrega una condición: `El issue se ha visto más de 10 veces en 1 hora`
+3. Agrega una acción: **Enviar notificación via webhook** → pega la URL de tu canal de Echobell
+4. Configura el tipo de notificación del canal en `urgencia temporal`
+
+Para rutas verdaderamente críticas — excepciones no controladas en flujos de pago, fallos de autenticación, corrupción de datos — crea una alerta separada con un umbral más bajo y un canal de Echobell en nivel `llamada`. Ese canal solo suena cuando algo en esa ruta específica falla.
+
+El resultado: los issues rutinarios se acumulan silenciosamente en tu panel de Sentry. Los problemas de producción críticos te llaman.
+
+## Prometheus y AlertManager: enrutar por severidad
+
+Si usas Prometheus, ya tienes AlertManager para el enrutamiento. Puedes enviar alertas directamente a Echobell añadiéndolo como receptor webhook.
+
+En tu `alertmanager.yml`:
+
+```yaml
+receivers:
+  - name: echobell-critical
+    webhook_configs:
+      - url: https://hook.echobell.one/YOUR_CHANNEL_ID
+        send_resolved: true
+
+  - name: slack-warnings
+    slack_configs:
+      - api_url: YOUR_SLACK_WEBHOOK
+
+route:
+  group_by: ['alertname', 'job']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: slack-warnings
+  routes:
+    - match:
+        severity: critical
+      receiver: echobell-critical
+```
+
+Con esta configuración, las alertas con `severity: critical` van a Echobell y hacen sonar tu teléfono; las advertencias van a Slack donde pueden esperar hasta la mañana. No necesitas cambiar ninguna regla de Prometheus — solo añades la capa de enrutamiento en AlertManager.
+
+Configura el canal de Echobell en **Llamada**. Si AlertManager lo llama crítico, merece un timbre real.
+
+## AWS CloudWatch: SNS → Lambda → Echobell
+
+CloudWatch no tiene salida webhook nativa, pero puedes lograrlo en pocos minutos con SNS y una pequeña función Lambda.
+
+1. Crea un topic SNS y vincúlalo a tu alarma de CloudWatch
+2. Crea una función Lambda suscrita a ese topic:
+
+```python
+import json
+import urllib.request
+
+def lambda_handler(event, context):
+    message = json.loads(event['Records'][0]['Sns']['Message'])
+    alarm_state = message.get('NewStateValue', 'UNKNOWN')
+
+    payload = {
+        "title": f"AWS: {message['AlarmName']}",
+        "body": message.get('NewStateReason', 'Sin detalles'),
+        "notificationType": "calling" if alarm_state == "ALARM" else "active"
+    }
+
+    req = urllib.request.Request(
+        'https://hook.echobell.one/YOUR_CHANNEL_ID',
+        data=json.dumps(payload).encode(),
+        headers={'Content-Type': 'application/json'},
+        method='POST'
+    )
+    urllib.request.urlopen(req)
+```
+
+Este patrón funciona para cualquier servicio de AWS que soporte SNS: eventos de RDS, fallos de servicio de ECS, alertas de umbral de facturación, cambios de estado de instancias EC2. Configuras una Lambda, la conectas a SNS, y cada alarma de CloudWatch se convierte en una llamada cuando realmente se activa.
+
+## Hacer del enrutamiento de alertas una decisión del equipo
+
+El verdadero apalancamiento con las alertas por niveles es hacer explícita la decisión de enrutamiento — no algo que alguien configuró una vez y nadie puede encontrar.
+
+Una estructura práctica para un equipo de ingeniería pequeño:
+
+| Canal | Tipo | Quién se suscribe |
+|---|---|---|
+| `production-api-critical` | Llamada | Ingeniero de guardia |
+| `production-api-warnings` | Urgencia temporal | Todo el equipo dev |
+| `staging-all` | Activo | Equipo dev (opcional) |
+| `background-jobs` | Activo | Quien esté interesado |
+
+Cuando cambia la rotación de guardia, la persona saliente cancela su suscripción al canal crítico y la entrante se suscribe. Ese es el traspaso completo de la rotación — sin archivos de configuración, sin paneles de administración.
+
+Los canales de Echobell son compartibles por enlace, suscribirse toma unos 10 segundos para cada nuevo miembro del equipo.
+
+## La prueba de señal a ruido
+
+Antes de añadir cualquier nueva alerta, hazte una pregunta: si esto se activa a las 3 de la madrugada de un viernes, ¿qué hago realmente?
+
+- "Me levanto y lo arreglo de inmediato" → Llamada
+- "Lo gestiono a primera hora de la mañana" → Urgencia temporal o Activo
+- "Probablemente nada, volvería a dormir" → reconsidera si la alerta debería existir
+
+La mayoría de los setups de monitoreo tienen demasiadas cosas en la primera categoría y muy pocas en la segunda. La respuesta correcta para la mayoría de los eventos es "gestionarlo mañana," y una notificación de urgencia temporal que aparece silenciosamente en la pantalla de bloqueo es exactamente la herramienta adecuada para eso.
+
+## Un cambio a la vez
+
+Si tu configuración actual está generando fatiga de alertas, la solución más rápida no es una revisión completa. Elige tu fuente más ruidosa — probablemente emails de Sentry o un canal de Slack que todos han silenciado — y categoriza cada tipo de evento en llamada, urgencia temporal o activo.
+
+Una fuente. Una semana. Comprueba si el ruido baja sin perder señal.
+
+Luego la siguiente.
+
+Un setup de alertas bien ajustado es uno de esos elementos que mejora tu vida laboral diaria de forma silenciosa y sin drama. Dejas de temer tu teléfono. Empiezas a confiar en que cuando suena, realmente importa.
+
+---
+
+## Relacionados
+
+- [Alertas de llamada telefónica cuando tu API cae](/en/blog/phone-call-alerts-api-downtime)
+- [Notificaciones de llamada con Grafana y Echobell](/en/blog/grafana-call-notification)
+- [Cómo eludir el Modo Enfoque de iOS para alertas críticas](/en/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [Condiciones de ventana temporal para alertas más inteligentes](/en/blog/time-window-notifications-using-utc-conditions)
+- [Automatización con n8n y Echobell](/en/blog/n8n-echobell-automation-hub)
+- [Notificaciones webhook para iPhone](/en/features/webhooks)

--- a/content/blog/fix-alert-fatigue-developer-guide.fr.mdx
+++ b/content/blog/fix-alert-fatigue-developer-guide.fr.mdx
@@ -1,0 +1,169 @@
+---
+title: "La fatigue des alertes est bien réelle : comment les bons développeurs s'en sortent"
+description: "Quand chaque alerte semble aussi urgente que la suivante, plus rien ne l'est vraiment. Voici comment améliorer votre configuration de monitoring avec des notifications hiérarchisées — et quels outils s'intègrent bien avec Echobell."
+date: 2026-04-17
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - fatigue des alertes
+  - monitoring
+  - Sentry
+  - Prometheus
+  - CloudWatch
+  - DevOps
+---
+
+# La fatigue des alertes est bien réelle : comment les bons développeurs s'en sortent
+
+Ça porte un nom : la fatigue des alertes. C'est ce qui se passe quand vos outils de monitoring envoient tellement de notifications que votre cerveau commence à les filtrer automatiquement — même celles qui comptent vraiment.
+
+Ça commence généralement petit. Vous configurez des alertes email pour chaque erreur 5xx. Ensuite des notifications Slack pour chaque build raté. Puis des pings Datadog, des emails Sentry, des SMS d'UptimeRobot. En un mois, votre téléphone vibre 50 fois par jour et rien ne semble urgent. Le pire dans tout ça ? Quand quelque chose casse vraiment, vous vous êtes déjà conditionné à ignorer les alertes.
+
+La fatigue des alertes détruit le temps de réponse. Et un mauvais temps de réponse détruit les produits.
+
+## Pourquoi la plupart des setups de monitoring génèrent plus de bruit que de signal
+
+Le problème fondamental, c'est que la plupart des outils d'alerte traitent tous les événements de la même façon. Un test instable qui échoue 10 % du temps reçoit le même format de notification que « l'API de paiement renvoie des 500 pour tous les utilisateurs ». L'un nécessite un appel téléphonique à 2h du matin. L'autre devrait figurer dans un résumé hebdomadaire.
+
+Quand tout reçoit le même traitement, les humains finissent par tout ignorer.
+
+La solution n'est pas moins d'alertes — c'est une livraison plus intelligente. Le même événement avec des niveaux de sévérité ou de fréquence différents devrait produire des niveaux d'urgence différents sur votre téléphone.
+
+## L'approche à trois niveaux
+
+Echobell propose trois modes de livraison, et bien les utiliser tous les trois, c'est toute la différence :
+
+- **Actif (Normal) :** Notification push standard. Bien pour les événements informatifs qui n'exigent pas d'action immédiate.
+- **Urgent :** Passe outre le Mode Concentration d'iOS. Adapté pour les choses qui nécessitent une attention dans l'heure ou les deux heures qui suivent.
+- **Appel :** Fait sonner votre téléphone comme un appel entrant. Réservez ça pour « corrigez ça maintenant ou il y aura de vraies conséquences ».
+
+L'objectif est de réserver le niveau appel aux événements où une réponse tardive a des conséquences réelles — revenus perdus, pannes en cascade, données utilisateurs à risque. Tout le reste passe en urgent ou moins.
+
+## Sentry : arrêtez d'être alerté pour chaque exception Python
+
+Sentry est l'exemple canonique de fatigue des alertes. Par défaut, il envoie un email pour chaque nouveau type d'issue. Sur une base de code active pendant une semaine normale, c'est un véritable déluge.
+
+Voici un setup plus intelligent :
+
+1. Dans Sentry : **Alertes → Créer une alerte → Alerte d'issue**
+2. Ajoutez une condition : `L'issue a été vue plus de 10 fois en 1 heure`
+3. Ajoutez une action : **Envoyer une notification via webhook** → collez l'URL de votre canal Echobell
+4. Configurez le type de notification du canal sur `urgent`
+
+Pour les chemins vraiment critiques — exceptions non gérées dans les flux de paiement, échecs d'authentification, corruption de données — créez une alerte séparée avec un seuil plus bas et un canal Echobell en niveau `appel`. Ce canal ne sonne que quand quelque chose dans ce chemin spécifique casse.
+
+Résultat : les issues routinières s'accumulent silencieusement dans votre tableau de bord Sentry. Les problèmes qui cassent la production vous appellent.
+
+## Prometheus et AlertManager : router par sévérité
+
+Si vous utilisez Prometheus, vous avez déjà AlertManager pour le routage. Vous pouvez envoyer des alertes directement à Echobell en l'ajoutant comme récepteur webhook.
+
+Dans votre `alertmanager.yml` :
+
+```yaml
+receivers:
+  - name: echobell-critical
+    webhook_configs:
+      - url: https://hook.echobell.one/YOUR_CHANNEL_ID
+        send_resolved: true
+
+  - name: slack-warnings
+    slack_configs:
+      - api_url: YOUR_SLACK_WEBHOOK
+
+route:
+  group_by: ['alertname', 'job']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: slack-warnings
+  routes:
+    - match:
+        severity: critical
+      receiver: echobell-critical
+```
+
+Avec cette configuration, les alertes `severity: critical` vont vers Echobell et font sonner votre téléphone ; les avertissements vont vers Slack où ils peuvent attendre jusqu'au lendemain matin. Vous n'avez pas besoin de changer une seule règle Prometheus — ajoutez simplement la couche de routage dans AlertManager.
+
+Configurez le canal Echobell lui-même sur **Appel**. Si AlertManager l'appelle critique, ça mérite une vraie sonnerie.
+
+## AWS CloudWatch : SNS → Lambda → Echobell
+
+CloudWatch n'a pas de sortie webhook native, mais vous pouvez y arriver en quelques minutes avec SNS et une petite fonction Lambda.
+
+1. Créez un topic SNS et attachez-le à votre alarme CloudWatch
+2. Créez une fonction Lambda abonnée à ce topic :
+
+```python
+import json
+import urllib.request
+
+def lambda_handler(event, context):
+    message = json.loads(event['Records'][0]['Sns']['Message'])
+    alarm_state = message.get('NewStateValue', 'UNKNOWN')
+
+    payload = {
+        "title": f"AWS: {message['AlarmName']}",
+        "body": message.get('NewStateReason', 'Pas de détails'),
+        "notificationType": "calling" if alarm_state == "ALARM" else "active"
+    }
+
+    req = urllib.request.Request(
+        'https://hook.echobell.one/YOUR_CHANNEL_ID',
+        data=json.dumps(payload).encode(),
+        headers={'Content-Type': 'application/json'},
+        method='POST'
+    )
+    urllib.request.urlopen(req)
+```
+
+Ce pattern fonctionne pour tout service AWS qui supporte SNS : événements RDS, échecs de service ECS, alertes de seuil de facturation, changements d'état d'instances EC2. Une Lambda configurée, connectée à SNS, et chaque alarme CloudWatch devient un appel téléphonique quand elle se déclenche vraiment.
+
+## Faire du routage des alertes une décision d'équipe
+
+Le vrai levier avec les alertes hiérarchisées, c'est de rendre la décision de routage explicite — pas quelque chose que quelqu'un a configuré une fois et que personne ne retrouve.
+
+Une structure pratique pour une petite équipe d'ingénierie :
+
+| Canal | Type | Qui s'abonne |
+|---|---|---|
+| `production-api-critical` | Appel | Ingénieur d'astreinte |
+| `production-api-warnings` | Urgent | Toute l'équipe dev |
+| `staging-all` | Actif | Équipe dev (optionnel) |
+| `background-jobs` | Actif | Les intéressés |
+
+Quand la rotation d'astreinte change, la personne sortante se désabonne du canal critique et la personne entrante s'y abonne. C'est tout le processus de passation — pas de fichiers de config à modifier, pas de panneau d'administration.
+
+Les canaux Echobell sont partageables par lien, s'abonner prend environ 10 secondes pour chaque nouveau membre de l'équipe.
+
+## Le test signal-sur-bruit
+
+Avant d'ajouter une nouvelle alerte, posez-vous une question : si ça se déclenche à 3h du matin un vendredi, qu'est-ce que je fais vraiment ?
+
+- « Je me lève et je règle ça immédiatement » → Appel
+- « Je m'en occupe dès le lendemain matin » → Urgent ou Actif
+- « Probablement rien, je me rendors » → reconsidérez si l'alerte devrait exister du tout
+
+La plupart des setups de monitoring ont trop de choses dans la première catégorie et pas assez dans la deuxième. La bonne réponse pour la majorité des événements, c'est « gérer ça demain » — et une notification urgente qui apparaît silencieusement sur l'écran de verrouillage est exactement le bon outil pour ça.
+
+## Un changement à la fois
+
+Si votre configuration actuelle génère de la fatigue des alertes, la solution la plus rapide n'est pas une refonte complète. Choisissez votre source la plus bruyante — probablement les emails Sentry ou un canal Slack que tout le monde a mis en sourdine — et catégorisez chaque type d'événement en appel, urgent ou actif.
+
+Une source. Une semaine. Voyez si le bruit diminue sans perdre de signal.
+
+Puis passez à la suivante.
+
+Un setup d'alertes bien réglé, c'est une de ces choses qui améliore silencieusement votre quotidien au travail, sans faire de bruit. Vous arrêtez de redouter votre téléphone. Vous commencez à faire confiance au fait que quand il sonne, ça compte vraiment.
+
+---
+
+## Liens utiles
+
+- [Alertes d'appel téléphonique quand votre API tombe](/en/blog/phone-call-alerts-api-downtime)
+- [Notifications d'appel Grafana avec Echobell](/en/blog/grafana-call-notification)
+- [Contourner le Mode Concentration d'iOS pour les alertes critiques](/en/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [Conditions de fenêtre temporelle pour des alertes plus intelligentes](/en/blog/time-window-notifications-using-utc-conditions)
+- [Hub d'automatisation avec n8n et Echobell](/en/blog/n8n-echobell-automation-hub)
+- [Notifications webhook pour iPhone](/en/features/webhooks)

--- a/content/blog/fix-alert-fatigue-developer-guide.ja.mdx
+++ b/content/blog/fix-alert-fatigue-developer-guide.ja.mdx
@@ -1,0 +1,169 @@
+---
+title: "アラート疲れは本物：賢い開発者がどうやって解決しているか"
+description: "すべてのアラートが同じように緊急に見えると、何も本当に緊急とは感じられなくなります。段階的な通知でモニタリング設定を改善する方法と、Echobellとの相性が良いツールを紹介します。"
+date: 2026-04-17
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - アラート疲れ
+  - モニタリング
+  - Sentry
+  - Prometheus
+  - CloudWatch
+  - DevOps
+---
+
+# アラート疲れは本物：賢い開発者がどうやって解決しているか
+
+これには名前があります。「アラート疲れ」です。モニタリングツールが大量の通知を送り続けた結果、脳が自動的にそれらをフィルタリングし始める現象のことです。本当に重要な通知でさえも。
+
+たいてい、小さなことから始まります。すべての5xxエラーにメールアラートを設定する。次に、失敗したビルドごとにSlack通知。そしてDatadogのping、Sentryのメール、UptimeRobotのテキスト。1ヶ月も経てば、電話が1日に50回振動するようになり、何も緊急に感じられなくなります。本当に怖いのはここです。何かが実際に壊れたとき、すでにそれを無視するよう自分を訓練してしまっているのです。
+
+アラート疲れは対応時間を破壊します。そして対応時間の遅さはプロダクトを破壊します。
+
+## なぜほとんどのモニタリング設定はシグナルよりもノイズを多く生むのか
+
+根本的な問題は、ほとんどのアラートツールがすべてのイベントを同じように扱うことです。10%の確率で失敗する不安定なテストが、「すべてのユーザーに対して決済APIが500を返している」と同じ通知フォーマットで届きます。片方は深夜2時に電話が必要な事態。もう片方は週次レポートで十分かもしれません。
+
+すべてが同じ扱いを受けると、人間はすべてを無視するようになります。
+
+解決策は、アラートを減らすことではありません。より賢い配信方法です。同じイベントでも、重大度や頻度が異なれば、電話での緊急度も異なるべきです。
+
+## 3段階アプローチ
+
+Echobellには3つの配信モードがあり、この3つをうまく使いこなすことが重要です。
+
+- **アクティブ（通常）：** 標準のプッシュ通知。即時対応を必要としない情報提供イベントに最適。
+- **時間的制約あり：** iOSの集中モードを突破します。1〜2時間以内の対応が必要な場合に適しています。
+- **通話：** 着信のように電話が鳴ります。「今すぐ修正しないと本当の問題になる」ケースのためだけに使います。
+
+目標は、対応が遅れると実際の影響が出るイベント（収益損失、連鎖障害、ユーザーデータのリスクなど）のためだけに通話レベルを残しておくことです。それ以外はすべて時間的制約あり以下に落とします。
+
+## Sentry：すべてのPython例外で呼び出されるのをやめる
+
+Sentryはアラート疲れの典型例です。デフォルトでは、新しい問題タイプごとにメールを送信します。活発なコードベースで普通の1週間を過ごすと、それは洪水のようになります。
+
+よりスマートな設定方法：
+
+1. Sentryで：**アラート → アラートを作成 → Issue アラート**
+2. 条件を追加：`1時間以内に10回以上見られたissue`
+3. アクションを追加：**Webhookで通知を送信** → EchobellチャンネルのURLを貼り付ける
+4. チャンネルの通知タイプを`時間的制約あり`に設定
+
+決済フローの未処理例外、認証失敗、データ破損など本当にクリティカルなパスには、より低い閾値と`通話`レベルのEchobellチャンネルを持つ別のアラートを作成してください。そのチャンネルは、その特定のパスで何かが壊れたときだけ鳴ります。
+
+結果：日常的なissueはSentryダッシュボードに静かに蓄積されます。プロダクションを壊す問題はあなたに電話してきます。
+
+## PrometheusとAlertManager：重大度でルーティング
+
+Prometheusを使っているなら、すでにルーティング用のAlertManagerがあります。EchobellをWebhookレシーバーとして追加することで、アラートを直接Echobellに送ることができます。
+
+`alertmanager.yml`の設定：
+
+```yaml
+receivers:
+  - name: echobell-critical
+    webhook_configs:
+      - url: https://hook.echobell.one/YOUR_CHANNEL_ID
+        send_resolved: true
+
+  - name: slack-warnings
+    slack_configs:
+      - api_url: YOUR_SLACK_WEBHOOK
+
+route:
+  group_by: ['alertname', 'job']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: slack-warnings
+  routes:
+    - match:
+        severity: critical
+      receiver: echobell-critical
+```
+
+この設定では、`severity: critical`のアラートがEchobellに行き電話が鳴り、warningはSlackに行って翌朝まで待機できます。Prometheusのルールを1つも変更する必要はありません。AlertManagerにルーティング層を追加するだけです。
+
+Echobellチャンネル自体は**通話**に設定してください。AlertManagerがcriticalと判断したなら、本物の着信音に値します。
+
+## AWS CloudWatch：SNS → Lambda → Echobell
+
+CloudWatchにはネイティブのWebhook出力がありませんが、SNSと小さなLambda関数を使えば数分で実現できます。
+
+1. SNSトピックを作成してCloudWatchアラームに接続する
+2. そのトピックをサブスクライブするLambda関数を作成する：
+
+```python
+import json
+import urllib.request
+
+def lambda_handler(event, context):
+    message = json.loads(event['Records'][0]['Sns']['Message'])
+    alarm_state = message.get('NewStateValue', 'UNKNOWN')
+
+    payload = {
+        "title": f"AWS: {message['AlarmName']}",
+        "body": message.get('NewStateReason', '詳細なし'),
+        "notificationType": "calling" if alarm_state == "ALARM" else "active"
+    }
+
+    req = urllib.request.Request(
+        'https://hook.echobell.one/YOUR_CHANNEL_ID',
+        data=json.dumps(payload).encode(),
+        headers={'Content-Type': 'application/json'},
+        method='POST'
+    )
+    urllib.request.urlopen(req)
+```
+
+このパターンはSNSをサポートするすべてのAWSサービスで機能します：RDSイベント、ECSサービス障害、請求閾値アラート、EC2インスタンス状態変更。Lambda1つを設定してSNSに接続するだけで、すべてのCloudWatchアラームが実際に発火したときに電話になります。
+
+## アラートルーティングをチームの意思決定にする
+
+段階的アラートの真の力は、ルーティングの決定を明示的にすること、つまり誰かが1回設定してもう誰も見つけられない、という状況をなくすことです。
+
+小規模なエンジニアリングチームへの実用的な構造：
+
+| チャンネル | タイプ | 誰がサブスクライブするか |
+|---|---|---|
+| `production-api-critical` | 通話 | オンコールエンジニア |
+| `production-api-warnings` | 時間的制約あり | 開発チーム全員 |
+| `staging-all` | アクティブ | 開発チーム（任意） |
+| `background-jobs` | アクティブ | 興味ある人 |
+
+オンコールのローテーションが変わったとき、交代する人がクリティカルチャンネルのサブスクリプションを解除し、引き継ぐ人がサブスクライブします。それがローテーション引き継ぎの全てです。設定ファイルも管理パネルも必要ありません。
+
+Echobellチャンネルはリンクで共有できるので、新しいメンバーのサブスクリプションは約10秒で完了します。
+
+## シグナル対ノイズテスト
+
+新しいアラートを追加する前に、1つの質問を自分に問いかけてください：金曜の深夜3時にこれが発火したら、実際に何をするか？
+
+- 「起きてすぐに直す」→ 通話
+- 「翌朝一番に対応する」→ 時間的制約あり、またはアクティブ
+- 「たぶん何もしない、また眠る」→ このアラートが本当に必要か再考する
+
+ほとんどのモニタリング設定は、最初のカテゴリに多すぎるものが入り、2番目のカテゴリには少なすぎます。ほとんどのイベントに対する正解は「明日対応する」であり、時間的制約ありの通知が静かにロック画面に表示されるのは、まさにそのための適切なツールです。
+
+## 一度に1つの変更
+
+現在の設定がアラート疲れを生んでいるなら、最も速い解決策は全面的な見直しではありません。最もうるさいソース（おそらくSentryのメールか、全員がミュートしたSlackチャンネル）を選んで、各イベントタイプを通話、時間的制約あり、またはアクティブに分類してください。
+
+1つのソース。1週間。シグナルを失わずにノイズが減るか確認する。
+
+次は次のソースへ。
+
+よく調整されたアラート設定は、毎日の仕事を静かに改善するものの一つです。大げさではありません。あなたは電話を恐れるのをやめます。鳴るときには本当に重要なことが起きているという信頼が生まれます。
+
+---
+
+## 関連リンク
+
+- [APIが落ちたときに電話で通知を受ける](/en/blog/phone-call-alerts-api-downtime)
+- [GrafanaとEchobellで通話通知を設定する](/en/blog/grafana-call-notification)
+- [重要なアラートでiOSの集中モードを突破する方法](/en/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [よりスマートなアラート配信のための時間窓条件](/en/blog/time-window-notifications-using-utc-conditions)
+- [n8nとEchobellで自動化ハブを構築する](/en/blog/n8n-echobell-automation-hub)
+- [iPhoneへのWebhook通知](/en/features/webhooks)

--- a/content/blog/fix-alert-fatigue-developer-guide.mdx
+++ b/content/blog/fix-alert-fatigue-developer-guide.mdx
@@ -1,0 +1,169 @@
+---
+title: "Alert Fatigue Is Real: How Smart Developers Actually Fix It"
+description: "When every alert looks equally urgent, nothing feels urgent. Here's how to fix your monitoring setup with tiered notifications — and which tools play nicely with Echobell."
+date: 2026-04-17
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - alert fatigue
+  - monitoring
+  - Sentry
+  - Prometheus
+  - CloudWatch
+  - DevOps
+---
+
+# Alert Fatigue Is Real: How Smart Developers Actually Fix It
+
+There's a name for it: alert fatigue. It's what happens when your monitoring tools send so many notifications that your brain starts filtering them out automatically — even the ones that matter.
+
+It usually starts small. You set up email alerts for every 5xx error. Then Slack notifications for every failed build. Then Datadog pings, Sentry emails, UptimeRobot texts. Within a month, your phone buzzes 50 times a day and none of it feels urgent. The really bad part? When something actually breaks, you've already trained yourself to ignore it.
+
+Alert fatigue kills response time. And slow response time kills products.
+
+## Why most monitoring setups create more noise than signal
+
+The fundamental problem is that most alerting tools treat all events the same. A flaky test that fails 10% of the time gets the same notification format as "the payment API is returning 500s for every user." One of those needs a phone call at 2 a.m. The other should probably show up in a weekly digest.
+
+When everything gets the same treatment, humans start ignoring everything.
+
+The fix isn't fewer alerts — it's smarter delivery. The same event at different severity levels, or with different frequency, should produce different urgency levels on your phone.
+
+## The three-tier approach
+
+Echobell gives you three delivery modes, and using all three well is the whole game:
+
+- **Active (Normal):** Standard push notification. Fine for informational events that don't need immediate action.
+- **Time-sensitive:** Breaks through iOS Focus Mode. Good for things that need attention within the next hour or two.
+- **Calling:** Rings your phone like an incoming call. Reserve this for "fix it right now or real consequences follow."
+
+The goal is to preserve the calling level for events where a delayed response has actual consequences — lost revenue, cascading failures, user data at risk. Everything else drops to time-sensitive or lower.
+
+## Sentry: Stop getting paged for every Python exception
+
+Sentry is the canonical example of alert fatigue. By default it emails you for every new issue type. On an active codebase during a normal week, that's a firehose.
+
+Here's a smarter setup:
+
+1. In Sentry, go to **Alerts → Create Alert → Issue Alert**
+2. Add a condition: `The issue is seen more than 10 times in 1 hour`
+3. Add action: **Send a notification via webhook** → paste your Echobell channel URL
+4. Set the channel's notification type to `time-sensitive`
+
+For truly critical paths — unhandled exceptions in payment flows, auth failures, data corruption — create a separate alert with a lower threshold and a `calling`-level Echobell channel. That channel only rings when something in that specific path breaks.
+
+The result: routine issues accumulate quietly in your Sentry dashboard. Production-breaking problems ring your phone.
+
+## Prometheus and AlertManager: Route by severity
+
+If you're running Prometheus, you already have AlertManager handling routing. You can send alerts directly to Echobell by adding it as a webhook receiver.
+
+In your `alertmanager.yml`:
+
+```yaml
+receivers:
+  - name: echobell-critical
+    webhook_configs:
+      - url: https://hook.echobell.one/YOUR_CHANNEL_ID
+        send_resolved: true
+
+  - name: slack-warnings
+    slack_configs:
+      - api_url: YOUR_SLACK_WEBHOOK
+
+route:
+  group_by: ['alertname', 'job']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: slack-warnings
+  routes:
+    - match:
+        severity: critical
+      receiver: echobell-critical
+```
+
+With this setup, `severity: critical` alerts go to Echobell and ring your phone; warnings go to Slack where they can wait until morning. You don't need to change a single Prometheus rule — just add the routing layer in AlertManager.
+
+Set the Echobell channel itself to **Calling**. If AlertManager labels it critical, it warrants a real ring.
+
+## AWS CloudWatch: SNS → Lambda → Echobell
+
+CloudWatch doesn't have native webhook output, but you can get there in a few minutes with SNS and a small Lambda function.
+
+1. Create an SNS topic and attach it to your CloudWatch alarm
+2. Create a Lambda function subscribed to that topic:
+
+```python
+import json
+import urllib.request
+
+def lambda_handler(event, context):
+    message = json.loads(event['Records'][0]['Sns']['Message'])
+    alarm_state = message.get('NewStateValue', 'UNKNOWN')
+
+    payload = {
+        "title": f"AWS: {message['AlarmName']}",
+        "body": message.get('NewStateReason', 'No details'),
+        "notificationType": "calling" if alarm_state == "ALARM" else "active"
+    }
+
+    req = urllib.request.Request(
+        'https://hook.echobell.one/YOUR_CHANNEL_ID',
+        data=json.dumps(payload).encode(),
+        headers={'Content-Type': 'application/json'},
+        method='POST'
+    )
+    urllib.request.urlopen(req)
+```
+
+This pattern works for any AWS service that supports SNS: RDS events, ECS service failures, billing threshold alerts, EC2 instance state changes. Add one Lambda, wire it to SNS, and every CloudWatch alarm becomes a phone call when it actually fires.
+
+## Making alert routing a team decision
+
+The real leverage with tiered alerts is making the routing decision explicit — not just something one person configured once and nobody can find.
+
+A practical structure for a small engineering team:
+
+| Channel | Type | Who subscribes |
+|---|---|---|
+| `production-api-critical` | Calling | On-call engineer |
+| `production-api-warnings` | Time-sensitive | Whole dev team |
+| `staging-all` | Active | Dev team (optional) |
+| `background-jobs` | Active | Anyone interested |
+
+When the on-call rotation changes, the outgoing person unsubscribes from the critical channel and the incoming person subscribes. That's the whole rotation handoff — no config files, no admin panels.
+
+Echobell channels are shareable via link, so subscribing takes about 10 seconds for each new team member.
+
+## The signal-to-noise test
+
+Before adding any new alert, ask one question: if this fires at 3 a.m. on a Friday, what do I actually do?
+
+- "Wake up and fix it immediately" → Calling
+- "Handle it first thing in the morning" → Time-sensitive or Active
+- "Probably nothing, I'd go back to sleep" → reconsider whether the alert should exist at all
+
+Most monitoring setups have too many things in the first category and not enough in the second. The right answer for the majority of events is "handle it tomorrow," and a time-sensitive notification that shows up on your lock screen without ringing is exactly the right tool for that.
+
+## One change at a time
+
+If your current setup is producing alert fatigue, the fastest fix isn't a full overhaul. Pick your noisiest source — probably Sentry emails or a Slack channel everyone has muted — and categorize each event type into calling, time-sensitive, or active.
+
+One source. One week. See if the noise drops without losing signal.
+
+Then do the next one.
+
+A well-tuned alert setup is one of those things that quietly improves your daily work life without being dramatic about it. You stop dreading your phone. You start trusting that when it rings, it actually matters.
+
+---
+
+## Related
+
+- [Getting phone call alerts when your API goes down](/en/blog/phone-call-alerts-api-downtime)
+- [Grafana call notifications with Echobell](/en/blog/grafana-call-notification)
+- [Bypassing iOS Focus Mode for critical alerts](/en/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [Time-window conditions for smarter alert delivery](/en/blog/time-window-notifications-using-utc-conditions)
+- [Building an automation hub with n8n and Echobell](/en/blog/n8n-echobell-automation-hub)
+- [Webhook notifications for iPhone](/en/features/webhooks)

--- a/content/blog/fix-alert-fatigue-developer-guide.zh.mdx
+++ b/content/blog/fix-alert-fatigue-developer-guide.zh.mdx
@@ -1,0 +1,169 @@
+---
+title: "告警疲劳是真实存在的：聪明的开发者如何应对"
+description: "当每个告警看起来都同样紧急时，就没有什么感觉紧急了。以下是如何通过分级通知改进你的监控设置——以及哪些工具与 Echobell 配合良好。"
+date: 2026-04-17
+author: Nooc
+authorAvatarLink: /images/avatars/nooc.webp
+authorLink: https://nooc.me
+tags:
+  - 告警疲劳
+  - 监控
+  - Sentry
+  - Prometheus
+  - CloudWatch
+  - DevOps
+---
+
+# 告警疲劳是真实存在的：聪明的开发者如何应对
+
+这个现象有个名字：告警疲劳。当你的监控工具发出太多通知，以至于你的大脑开始自动过滤它们——即使是那些真正重要的通知，这就是告警疲劳。
+
+通常从小事开始。你为每个 5xx 错误设置了邮件告警，然后为每个失败的构建设置了 Slack 通知，接着又有 Datadog 的 ping、Sentry 的邮件、UptimeRobot 的短信。一个月后，你的手机每天振动 50 次，没有任何事情感觉是紧急的。最糟糕的是：当某些事情真的出了问题，你已经训练自己去忽略这些通知了。
+
+告警疲劳会摧毁响应时间。而慢响应会摧毁产品。
+
+## 为什么大多数监控设置产生的噪音多于信号
+
+根本问题在于，大多数告警工具对所有事件一视同仁。一个 10% 概率失败的不稳定测试和"支付 API 对每个用户都返回 500"收到相同格式的通知。其中一个需要凌晨 2 点打电话。另一个也许应该出现在周报里。
+
+当所有事情都得到相同对待，人们开始忽略所有事情。
+
+解决方案不是减少告警——而是更智能的投递。相同的事件在不同严重程度或频率下，应该在你的手机上产生不同的紧急级别。
+
+## 三级分层方法
+
+Echobell 提供三种投递模式，把这三种模式都用好才是关键：
+
+- **活跃（普通）：** 标准推送通知。适合不需要立即行动的信息性事件。
+- **时间敏感：** 突破 iOS 专注模式。适合需要在一两小时内处理的事情。
+- **来电：** 像来电一样让你的手机响铃。只在"现在必须修复，否则会有真实后果"的情况下使用。
+
+目标是把来电级别保留给那些响应延迟会有实际后果的事件——损失的收入、级联故障、用户数据风险。其他所有事情降级为时间敏感或更低。
+
+## Sentry：别让每个 Python 异常都叫醒你
+
+Sentry 是告警疲劳的典型案例。默认情况下，它会为每种新的 issue 类型发送邮件。在一个活跃的代码库上，一周下来那就是洪水。
+
+更智能的设置方法：
+
+1. 在 Sentry 中：**告警 → 创建告警 → Issue 告警**
+2. 添加条件：`在 1 小时内被看到超过 10 次`
+3. 添加操作：**通过 webhook 发送通知** → 粘贴你的 Echobell 频道 URL
+4. 将频道的通知类型设置为`时间敏感`
+
+对于真正关键的路径——支付流程中的未处理异常、认证失败、数据损坏——创建一个单独的告警，使用更低的阈值和`来电`级别的 Echobell 频道。那个频道只在该特定路径出现问题时才会响铃。
+
+结果：日常 issue 在你的 Sentry 仪表盘中静静积累。破坏生产环境的问题会给你打电话。
+
+## Prometheus 和 AlertManager：按严重程度路由
+
+如果你在使用 Prometheus，你已经有了用于路由的 AlertManager。通过将 Echobell 添加为 webhook 接收器，你可以将告警直接发送到 Echobell。
+
+在你的 `alertmanager.yml` 中：
+
+```yaml
+receivers:
+  - name: echobell-critical
+    webhook_configs:
+      - url: https://hook.echobell.one/YOUR_CHANNEL_ID
+        send_resolved: true
+
+  - name: slack-warnings
+    slack_configs:
+      - api_url: YOUR_SLACK_WEBHOOK
+
+route:
+  group_by: ['alertname', 'job']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  receiver: slack-warnings
+  routes:
+    - match:
+        severity: critical
+      receiver: echobell-critical
+```
+
+有了这个设置，`severity: critical` 的告警会去 Echobell 并让你的手机响铃；警告去 Slack，可以等到早上再处理。你不需要更改任何 Prometheus 规则——只需在 AlertManager 中添加路由层。
+
+将 Echobell 频道本身设置为**来电**。如果 AlertManager 认为它是关键的，那就值得一个真实的铃声。
+
+## AWS CloudWatch：SNS → Lambda → Echobell
+
+CloudWatch 没有原生的 webhook 输出，但你可以用 SNS 和一个小型 Lambda 函数在几分钟内实现。
+
+1. 创建一个 SNS 主题并将其附加到你的 CloudWatch 告警
+2. 创建一个订阅该主题的 Lambda 函数：
+
+```python
+import json
+import urllib.request
+
+def lambda_handler(event, context):
+    message = json.loads(event['Records'][0]['Sns']['Message'])
+    alarm_state = message.get('NewStateValue', 'UNKNOWN')
+
+    payload = {
+        "title": f"AWS: {message['AlarmName']}",
+        "body": message.get('NewStateReason', '无详情'),
+        "notificationType": "calling" if alarm_state == "ALARM" else "active"
+    }
+
+    req = urllib.request.Request(
+        'https://hook.echobell.one/YOUR_CHANNEL_ID',
+        data=json.dumps(payload).encode(),
+        headers={'Content-Type': 'application/json'},
+        method='POST'
+    )
+    urllib.request.urlopen(req)
+```
+
+这个模式适用于任何支持 SNS 的 AWS 服务：RDS 事件、ECS 服务故障、账单阈值告警、EC2 实例状态变更。配置一个 Lambda，连接到 SNS，每个 CloudWatch 告警真正触发时就会变成电话。
+
+## 让告警路由成为团队决策
+
+分级告警的真正杠杆在于使路由决策显式化——而不是某人在某时配置了一次，没有人能找到的东西。
+
+小型工程团队的实用结构：
+
+| 频道 | 类型 | 谁订阅 |
+|---|---|---|
+| `production-api-critical` | 来电 | 值班工程师 |
+| `production-api-warnings` | 时间敏感 | 整个开发团队 |
+| `staging-all` | 活跃 | 开发团队（可选） |
+| `background-jobs` | 活跃 | 有兴趣的人 |
+
+当值班轮换时，离任的人取消订阅关键频道，接任的人订阅。这就是整个轮换交接——不需要编辑配置文件，不需要管理员面板。
+
+Echobell 频道可以通过链接共享，新成员订阅只需约 10 秒。
+
+## 信噪比测试
+
+在添加任何新告警之前，问自己一个问题：如果这个在周五凌晨 3 点触发，我实际上会怎么做？
+
+- "起床立即修复" → 来电
+- "明天早上第一件事处理" → 时间敏感或活跃
+- "可能什么都不做，继续睡觉" → 重新考虑这个告警是否应该存在
+
+大多数监控设置在第一类别中有太多东西，在第二类别中太少。大多数事件的正确答案是"明天处理"，而一个静静出现在锁屏上的时间敏感通知正是为此准备的合适工具。
+
+## 一次只改一个
+
+如果你当前的设置正在产生告警疲劳，最快的解决方案不是全面重构。选择你最嘈杂的来源——可能是 Sentry 邮件或一个每个人都静音的 Slack 频道——然后将每种事件类型归类为来电、时间敏感或活跃。
+
+一个来源。一周时间。看看噪音是否在不失去信号的情况下降低。
+
+然后处理下一个。
+
+一个调整良好的告警设置是那些不声不响地改善你日常工作生活的东西之一。你不再害怕手机响。你开始相信，当它响的时候，那真的是重要的事情。
+
+---
+
+## 相关链接
+
+- [当 API 宕机时获取电话警报](/en/blog/phone-call-alerts-api-downtime)
+- [Grafana 电话通知与 Echobell](/en/blog/grafana-call-notification)
+- [如何让关键告警突破 iOS 专注模式](/en/blog/how-to-bypass-ios-focus-mode-for-critical-alerts)
+- [使用时间窗口条件实现更智能的告警投递](/en/blog/time-window-notifications-using-utc-conditions)
+- [使用 n8n 和 Echobell 构建自动化中枢](/en/blog/n8n-echobell-automation-hub)
+- [iPhone 的 Webhook 通知](/en/features/webhooks)


### PR DESCRIPTION
## Summary

- Adds a new marketing blog post: **"Alert Fatigue Is Real: How Smart Developers Actually Fix It"**
- Published in all 6 supported languages: English, German, Spanish, French, Japanese, Chinese
- Slug: `fix-alert-fatigue-developer-guide`

## What changed

6 new MDX files under `content/blog/`:

| File | Language |
|---|---|
| `fix-alert-fatigue-developer-guide.mdx` | English |
| `fix-alert-fatigue-developer-guide.de.mdx` | German |
| `fix-alert-fatigue-developer-guide.es.mdx` | Spanish |
| `fix-alert-fatigue-developer-guide.fr.mdx` | French |
| `fix-alert-fatigue-developer-guide.ja.mdx` | Japanese |
| `fix-alert-fatigue-developer-guide.zh.mdx` | Chinese |

## Why

The existing blog covers use cases and integrations broadly (`echobell-use-cases-and-integrations`, `echobell-complete-alert-guide`), but no post specifically addresses **alert fatigue** — a widely searched developer pain point. This post fills that gap with:

- Concrete Sentry alert rule configuration to reduce noise
- Prometheus AlertManager severity-based routing to Echobell
- AWS CloudWatch → SNS → Lambda → Echobell pattern with working code
- Team on-call channel structure without PagerDuty complexity
- A "signal-to-noise test" heuristic for evaluating new alerts

SEO targets: `alert fatigue developer`, `sentry webhook notification`, `prometheus alertmanager ios`, `cloudwatch webhook notification`.

## Test plan

- [ ] Check blog listing page at `/en/blog` shows the new post
- [ ] Verify each language route loads (`/de/blog`, `/es/blog`, `/fr/blog`, `/ja/blog`, `/zh/blog`)
- [ ] Confirm frontmatter renders correctly (title, date, description, tags)
- [ ] Check internal links in the Related section resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)